### PR TITLE
fix: Copy NuGet package to LocalNuGetFeed in release workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -59,6 +59,8 @@ jobs:
         run: |
           echo "Building TimeWarp.Nuru for release (GeneratePackageOnBuild=true)..."
           dotnet build Source/TimeWarp.Nuru/TimeWarp.Nuru.csproj --configuration Release
+          echo "Copying NuGet package to LocalNuGetFeed..."
+          cp Source/TimeWarp.Nuru/bin/Release/*.nupkg LocalNuGetFeed/
 
       - name: Check if version already published (Releases only)
         if: github.event_name == 'release'


### PR DESCRIPTION
## Summary
Fixed the release workflow to properly copy the NuGet package to LocalNuGetFeed directory before attempting to publish.

## Problem
The v1.0.0-beta.1 release failed because:
- The package was created in `Source/TimeWarp.Nuru/bin/Release/`
- But the publish step was looking for it in `LocalNuGetFeed/`

## Solution
Added a copy command to move the generated .nupkg file to the LocalNuGetFeed directory after building for release.

This fix ensures the package can be successfully published to NuGet.org when a release is created.

🤖 Generated with [Claude Code](https://claude.ai/code)