### PR TITLE
feat: Update to TimeWarp.Mediator beta.3 and bump version to beta.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     
     <!-- Package Metadata -->
+    <Version>1.0.0-beta.2</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-nuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.7" />
-    <PackageVersion Include="TimeWarp.Mediator" Version="13.0.0-beta.2" />
+    <PackageVersion Include="TimeWarp.Mediator" Version="13.0.0-beta.3" />
     <PackageVersion Include="TimeWarp.Cli" Version="0.6.0-rc12" />
     <!-- Benchmark packages -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />

--- a/Samples/Calculator/calc-mediator
+++ b/Samples/Calculator/calc-mediator
@@ -10,7 +10,7 @@ var builder = new AppBuilder();
 
 // Register services
 builder.Services.AddSingleton<ICalculatorService, CalculatorService>();
-builder.Services.AddMediatR(config => config.RegisterServicesFromAssembly(typeof(AddCommand).Assembly));
+builder.Services.AddMediator(config => config.RegisterServicesFromAssembly(typeof(AddCommand).Assembly));
 
 // Define routes - no return type needed, just console output
 builder.AddRoute<AddCommand>("add {x:double} {y:double}");

--- a/Samples/Calculator/calc-mixed
+++ b/Samples/Calculator/calc-mixed
@@ -10,7 +10,7 @@ var builder = new AppBuilder();
 
 // Register services for complex operations
 builder.Services.AddSingleton<IScientificCalculator, ScientificCalculator>();
-builder.Services.AddMediatR(config => config.RegisterServicesFromAssembly(typeof(FactorialCommand).Assembly));
+builder.Services.AddMediator(config => config.RegisterServicesFromAssembly(typeof(FactorialCommand).Assembly));
 
 // Use Direct approach for simple operations (performance)
 builder.AddRoute("add {x:double} {y:double}", 

--- a/Source/TimeWarp.Nuru/TimeWarp.Nuru.csproj
+++ b/Source/TimeWarp.Nuru/TimeWarp.Nuru.csproj
@@ -4,7 +4,6 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Route-based CLI framework for .NET - bringing web-style routing to command-line applications</Description>
     <PackageTags>cli;command-line;routing;framework;dotnet;console;consoleappframework;commandlineparser;mcmaster;cocona;spectre;system-commandline;clipr;commanddotnet</PackageTags>
-    <Version>1.0.0-beta.1</Version>
     <!-- Disable localization warning as CLI frameworks don't typically need localization -->
     <NoWarn>$(NoWarn);CA1303</NoWarn>
     <!-- Enforce code style rules during build -->

--- a/Tests/TimeWarp.Nuru.TestApp.Mediator/Program.cs
+++ b/Tests/TimeWarp.Nuru.TestApp.Mediator/Program.cs
@@ -5,7 +5,7 @@ using TimeWarp.Nuru;
 var builder = new AppBuilder();
 
 // Add services
-builder.Services.AddMediatR(config => config.RegisterServicesFromAssembly(typeof(StatusCommand).Assembly));
+builder.Services.AddMediator(config => config.RegisterServicesFromAssembly(typeof(StatusCommand).Assembly));
 
 // Test 1: Basic Commands (2)
 builder.AddRoute<StatusCommand>("status");


### PR DESCRIPTION
## Summary
- Update TimeWarp.Mediator from beta.2 to beta.3 
- Migrate from `AddMediatR` to `AddMediator` method (breaking change in beta.3)
- Bump TimeWarp.Nuru version from beta.1 to beta.2

## Changes
- Updated TimeWarp.Mediator package reference to 13.0.0-beta.3
- Replaced all `AddMediatR` calls with `AddMediator` in:
  - Tests/TimeWarp.Nuru.TestApp.Mediator/Program.cs
  - Samples/Calculator/calc-mixed
  - Samples/Calculator/calc-mediator
- Moved Version property from TimeWarp.Nuru.csproj to Directory.Build.props for centralization
- Bumped version to 1.0.0-beta.2

## Test Results
All tests pass successfully with the new version:
- ✅ 37/37 tests pass for Delegate implementation (JIT & AOT)
- ✅ 37/37 tests pass for Mediator implementation (JIT & AOT)
- ✅ Build completes successfully with no errors

🤖 Generated with [Claude Code](https://claude.ai/code)