### PR TITLE
fix: Update CI/CD workflow to read version from Directory.Build.props

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Check if version already published (Releases only)
         if: github.event_name == 'release'
         run: |
-          VERSION=$(grep '<Version>' Source/TimeWarp.Nuru/TimeWarp.Nuru.csproj | sed 's/.*<Version>\(.*\)<\/Version>.*/\1/')
+          VERSION=$(grep '<Version>' Directory.Build.props | sed 's/.*<Version>\(.*\)<\/Version>.*/\1/')
           echo "Checking if TimeWarp.Nuru $VERSION is already published on NuGet.org..."
           
           # Check TimeWarp.Nuru using package search - only check NuGet.org source


### PR DESCRIPTION
The version property was moved from the csproj file to Directory.Build.props for centralization, but the CI/CD workflow was still looking in the old location. This was causing the release build to fail.

This fix updates the workflow to read the version from the correct location.

🤖 Generated with [Claude Code](https://claude.ai/code)