### PR TITLE
Add rounding modes to calculator help text

### DIFF
--- a/Samples/Calculator/calc-direct
+++ b/Samples/Calculator/calc-direct
@@ -75,7 +75,7 @@ var app = new DirectAppBuilder()
             "  subtract <x> <y>         - Subtract y from x\n" +
             "  multiply <x> <y>         - Multiply two numbers\n" +
             "  divide <x> <y>           - Divide x by y\n" +
-            "  round <value> [--mode]   - Round a number\n" +
+            "  round <value> [--mode]   - Round a number (modes: up, down, nearest, banker)\n" +
             "\n" +
             "Add 'help' after any command for detailed usage."))
     

--- a/Samples/Calculator/calc-mediator
+++ b/Samples/Calculator/calc-mediator
@@ -39,7 +39,7 @@ builder.AddRoute("help",
         "  subtract <x> <y>         - Subtract y from x\n" +
         "  multiply <x> <y>         - Multiply two numbers\n" +
         "  divide <x> <y>           - Divide x by y\n" +
-        "  round <value> [--mode]   - Round a number\n" +
+        "  round <value> [--mode]   - Round a number (modes: up, down, nearest, banker)\n" +
         "\n" +
         "Add 'help' after any command for detailed usage."));
 


### PR DESCRIPTION
## Summary
- Updated help text in `calc-mediator` and `calc-direct` to show available rounding modes inline
- Modes shown: up, down, nearest, banker

## Test plan
- [ ] Run `./calc-mediator help` and verify rounding modes are displayed
- [ ] Run `./calc-direct help` and verify rounding modes are displayed
- [ ] Test actual rounding functionality with each mode

🤖 Generated with [Claude Code](https://claude.ai/code)