### PR TITLE
Fix CI/CD workflow version detection

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -69,7 +69,7 @@ jobs:
           echo "Checking if TimeWarp.Nuru $VERSION is already published on NuGet.org..."
           
           # Check TimeWarp.Nuru using package search - only check NuGet.org source
-          if dotnet package search TimeWarp.Nuru --exact-match --prerelease --source https://api.nuget.org/v3/index.json | grep -q "$VERSION"; then
+          if dotnet package search TimeWarp.Nuru --exact-match --prerelease --source https://api.nuget.org/v3/index.json | grep -q "| $VERSION |"; then
             echo "⚠️ WARNING: TimeWarp.Nuru $VERSION is already published to NuGet.org"
             echo "❌ This version cannot be republished. Please increment the version in TimeWarp.Nuru.csproj"
             exit 1


### PR DESCRIPTION
## Summary
Fixes the NuGet version detection in the CI/CD workflow to prevent false positives when checking if a version is already published.

## Problem
The workflow was incorrectly detecting that version 1.0.0 was already published because the grep pattern was matching:
- `1.0.0-beta.1` 
- `1.0.0-beta.2`

## Solution
Changed the grep pattern from `"$VERSION"` to `"| $VERSION |"` to match the exact version in the table format output.

## Test
This will allow the 1.0.0 release to be properly published to NuGet.

🤖 Generated with [Claude Code](https://claude.ai/code)