### PR TITLE
fix: Release v2.1.0-beta.2 with runtime dependency fix

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     
     <!-- Package Metadata -->
-    <Version>2.1.0-beta.1</Version>
+    <Version>2.1.0</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-nuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     
     <!-- Package Metadata -->
-    <Version>2.1.0</Version>
+    <Version>2.1.0-beta.2</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-nuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>

--- a/Source/TimeWarp.Nuru.Parsing/TimeWarp.Nuru.Parsing.csproj
+++ b/Source/TimeWarp.Nuru.Parsing/TimeWarp.Nuru.Parsing.csproj
@@ -1,31 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-    <ContentTargetFolders>content</ContentTargetFolders>
-    <DevelopmentDependency>true</DevelopmentDependency>
-    <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>
     <PackageId>TimeWarp.Nuru.Parsing</PackageId>
-    <Description>Source-only package containing route pattern parsing for TimeWarp.Nuru</Description>
+    <Description>Route pattern parsing library for TimeWarp.Nuru</Description>
     <PackageTags>TimeWarp;Nuru;Parsing;Source;Analyzer</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
-  <ItemGroup>
-    <!-- All .cs files will be included as content -->
-    <Content Include="**/*.cs" Exclude="obj/**;bin/**">
-      <Pack>true</Pack>
-      <PackagePath>contentFiles/cs/any/TimeWarp.Nuru.Parsing/</PackagePath>
-      <BuildAction>Compile</BuildAction>
-    </Content>
-  </ItemGroup>
 
   <ItemGroup>
     <None Include="../../Assets/Logo.png" Pack="true" PackagePath="" />

--- a/Source/TimeWarp.Nuru/TimeWarp.Nuru.csproj
+++ b/Source/TimeWarp.Nuru/TimeWarp.Nuru.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\TimeWarp.Nuru.Parsing\TimeWarp.Nuru.Parsing.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\TimeWarp.Nuru.Parsing\TimeWarp.Nuru.Parsing.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
Critical fix for FileNotFoundException + analyzer package release

## Changes
- Fixed TimeWarp.Nuru.Parsing to be a proper runtime dependency
- Removed PrivateAssets="all" that was causing the parsing assembly to be missing at runtime
- Version bumped to 2.1.0-beta.2
- Includes new TimeWarp.Nuru.Analyzers package

## Packages to be published
- TimeWarp.Nuru 2.1.0-beta.2 (with Parsing dependency)
- TimeWarp.Nuru.Parsing 2.1.0-beta.2 (now a regular package)
- TimeWarp.Nuru.Analyzers 2.1.0-beta.2 (first release)

## Test Plan
- [x] Build succeeds
- [x] Package dependencies verified
- [ ] Runtime test with external project

🤖 Generated with [Claude Code](https://claude.ai/code)