### PR TITLE
fix: Release v2.1.0-beta.3 - analyzer build fix

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     
     <!-- Package Metadata -->
-    <Version>2.1.0-beta.2</Version>
+    <Version>2.1.0-beta.3</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-nuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>

--- a/Source/TimeWarp.Nuru.Analyzers/TimeWarp.Nuru.Analyzers.csproj
+++ b/Source/TimeWarp.Nuru.Analyzers/TimeWarp.Nuru.Analyzers.csproj
@@ -28,9 +28,6 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\TimeWarp.Nuru\TimeWarp.Nuru.csproj" PrivateAssets="all" GeneratePathProperty="true" />
-  </ItemGroup>
 
   <!-- Include parsing source files directly -->
   <ItemGroup>
@@ -39,7 +36,6 @@
 
   <ItemGroup>
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-    <None Include="$(PkgTimeWarp_Nuru)\lib\$(TargetFramework)\*.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
Fix analyzer build conflicts by removing TimeWarp.Nuru reference

## Changes
- Removed ProjectReference to TimeWarp.Nuru from analyzer project
- Analyzer only needs to compile parsing source, not reference the main assembly
- Version bumped to 2.1.0-beta.3

This fixes the type conflict errors seen in CI.

🤖 Generated with [Claude Code](https://claude.ai/code)