### PR TITLE
fix: GitHub Actions workflow improvements and build consistency

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,63 +36,18 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      - name: Make scripts executable
-        run: |
-          chmod +x Scripts/Build.cs
-          chmod +x Scripts/*.cs
-          chmod +x Tests/test-both-versions.sh
-
-      - name: Create LocalNuGetFeed directory
-        run: mkdir -p LocalNuGetFeed
-
       - name: Build and Test
         run: |
-          echo "Building TimeWarp.Nuru..."
-          dotnet build Source/TimeWarp.Nuru/TimeWarp.Nuru.csproj --configuration Release
-          
-          echo "Building TimeWarp.Nuru.Analyzers..."
-          dotnet build Source/TimeWarp.Nuru.Analyzers/TimeWarp.Nuru.Analyzers.csproj --configuration Release
+          echo "Running build script..."
+          ./Scripts/Build.cs
           
           echo "Running integration tests..."
           cd Tests
           ./test-both-versions.sh
 
-      - name: Build for Release
-        if: github.event_name == 'release'
-        run: |
-          echo "Building TimeWarp.Nuru for release (GeneratePackageOnBuild=true)..."
-          dotnet build Source/TimeWarp.Nuru/TimeWarp.Nuru.csproj --configuration Release
-          
-          echo "Building TimeWarp.Nuru.Analyzers for release (GeneratePackageOnBuild=true)..."
-          dotnet build Source/TimeWarp.Nuru.Analyzers/TimeWarp.Nuru.Analyzers.csproj --configuration Release
-          
-          echo "Copying NuGet packages to LocalNuGetFeed..."
-          cp Source/TimeWarp.Nuru/bin/Release/*.nupkg LocalNuGetFeed/
-          cp Source/TimeWarp.Nuru.Analyzers/bin/Release/*.nupkg LocalNuGetFeed/
-
       - name: Check if version already published (Releases only)
         if: github.event_name == 'release'
-        run: |
-          VERSION=$(grep '<Version>' Directory.Build.props | sed 's/.*<Version>\(.*\)<\/Version>.*/\1/')
-          echo "Checking if packages with version $VERSION are already published on NuGet.org..."
-          
-          # Check TimeWarp.Nuru using package search - only check NuGet.org source
-          if dotnet package search TimeWarp.Nuru --exact-match --prerelease --source https://api.nuget.org/v3/index.json | grep -q "| $VERSION |"; then
-            echo "⚠️ WARNING: TimeWarp.Nuru $VERSION is already published to NuGet.org"
-            echo "❌ This version cannot be republished. Please increment the version in Directory.Build.props"
-            exit 1
-          else
-            echo "✅ TimeWarp.Nuru $VERSION is not yet published on NuGet.org"
-          fi
-          
-          # Check TimeWarp.Nuru.Analyzers using package search - only check NuGet.org source
-          if dotnet package search TimeWarp.Nuru.Analyzers --exact-match --prerelease --source https://api.nuget.org/v3/index.json | grep -q "| $VERSION |"; then
-            echo "⚠️ WARNING: TimeWarp.Nuru.Analyzers $VERSION is already published to NuGet.org"
-            echo "❌ This version cannot be republished. Please increment the version in Directory.Build.props"
-            exit 1
-          else
-            echo "✅ TimeWarp.Nuru.Analyzers $VERSION is not yet published on NuGet.org"
-          fi
+        run: ./Scripts/CheckVersion.cs
 
       - name: Publish to NuGet.org (Releases only)
         if: github.event_name == 'release'

--- a/Scripts/CheckVersion.cs
+++ b/Scripts/CheckVersion.cs
@@ -1,0 +1,57 @@
+#!/usr/bin/dotnet --
+// CheckVersion.cs - Check if NuGet packages are already published
+
+using System.Xml.Linq;
+
+// Change to script directory for relative paths
+string scriptDir = (AppContext.GetData("EntryPointFileDirectoryPath") as string)!;
+Directory.SetCurrentDirectory(scriptDir);
+
+// Read version from Directory.Build.props
+string propsPath = "../Directory.Build.props";
+var doc = XDocument.Load(propsPath);
+string? version = doc.Descendants("Version").FirstOrDefault()?.Value;
+
+if (string.IsNullOrEmpty(version))
+{
+    WriteLine("❌ Could not find version in Directory.Build.props");
+    Environment.Exit(1);
+}
+
+WriteLine($"Checking if packages with version {version} are already published on NuGet.org...");
+
+// Packages to check
+string[] packages = ["TimeWarp.Nuru", "TimeWarp.Nuru.Analyzers"];
+bool anyPublished = false;
+
+foreach (string package in packages)
+{
+    WriteLine($"\nChecking {package}...");
+
+    CommandResult searchResult = DotNet.PackageSearch(package)
+        .WithExactMatch()
+        .WithPrerelease()
+        .WithSource("https://api.nuget.org/v3/index.json")
+        .Build();
+
+    ExecutionResult result = await searchResult.ExecuteAsync();
+
+    // Check if the version appears in the output
+    if (result.StandardOutput.Contains($"| {version} |", StringComparison.Ordinal))
+    {
+        WriteLine($"⚠️  WARNING: {package} {version} is already published to NuGet.org");
+        anyPublished = true;
+    }
+    else
+    {
+        WriteLine($"✅ {package} {version} is not yet published on NuGet.org");
+    }
+}
+
+if (anyPublished)
+{
+    WriteLine("\n❌ One or more packages are already published. Please increment the version in Directory.Build.props");
+    Environment.Exit(1);
+}
+
+WriteLine("\n✅ All packages are ready to publish!");

--- a/Source/TimeWarp.Nuru.Analyzers/TimeWarp.Nuru.Analyzers.csproj
+++ b/Source/TimeWarp.Nuru.Analyzers/TimeWarp.Nuru.Analyzers.csproj
@@ -6,6 +6,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageOutputPath>../../LocalNuGetFeed</PackageOutputPath>
     <DevelopmentDependency>true</DevelopmentDependency>
     <!-- Suppress RS1041 since we're intentionally targeting .NET 9 for CLI usage -->
     <!-- Suppress CA1805, CA1802, RCS1163 for parsing code that's compiled in -->

--- a/Source/TimeWarp.Nuru/TimeWarp.Nuru.csproj
+++ b/Source/TimeWarp.Nuru/TimeWarp.Nuru.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageOutputPath>../../LocalNuGetFeed</PackageOutputPath>
     <Description>Route-based CLI framework for .NET - bringing web-style routing to command-line applications</Description>
     <PackageTags>cli;command-line;routing;framework;dotnet;console;consoleappframework;commandlineparser;mcmaster;cocona;spectre;system-commandline;clipr;commanddotnet</PackageTags>
     <!-- Disable localization warning as CLI frameworks don't typically need localization -->


### PR DESCRIPTION
## Summary
- Fixed GitHub Actions workflow to properly build source-only packages
- Improved build consistency by using C# scripts throughout
- Replaced bash scripts with strongly typed C# alternatives

## Changes

### Workflow Improvements
- Use Build.cs script for all builds (ensures consistent Release mode)
- Removed redundant "Build for Release" step
- Removed unnecessary chmod commands (scripts already have execute permissions)

### Package Output Consistency
- Configured all projects to output packages to LocalNuGetFeed
- TimeWarp.Nuru.csproj now uses `<PackageOutputPath>../../LocalNuGetFeed</PackageOutputPath>`
- TimeWarp.Nuru.Analyzers.csproj now uses `<PackageOutputPath>../../LocalNuGetFeed</PackageOutputPath>`
- No more manual copying of .nupkg files

### Version Check Script
- Created CheckVersion.cs to replace bash version checking
- Uses strongly typed `DotNet.PackageSearch()` from Amuru
- More maintainable and consistent with other build scripts
- Proper error handling and clear output

## Test Plan
- [x] Build.cs script works locally
- [x] CheckVersion.cs script tested and working
- [x] All packages output to LocalNuGetFeed during build
- [ ] GitHub Actions workflow runs successfully

This fixes the build failures that occurred after merging the analyzer implementation.

🤖 Generated with [Claude Code](https://claude.ai/code)