### PR TITLE
Fix boolean option binding and prevent source-only packages from NuGet publication

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -55,7 +55,11 @@ jobs:
       - name: Publish to NuGet.org (Releases only)
         if: github.event_name == 'release'
         run: |
-          dotnet nuget push LocalNuGetFeed/*.nupkg \
+          dotnet nuget push LocalNuGetFeed/TimeWarp.Nuru.${{ env.VERSION }}.nupkg \
+            --api-key ${{ secrets.NUGET_API_KEY }} \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate
+          dotnet nuget push LocalNuGetFeed/TimeWarp.Nuru.Analyzers.${{ env.VERSION }}.nupkg \
             --api-key ${{ secrets.NUGET_API_KEY }} \
             --source https://api.nuget.org/v3/index.json \
             --skip-duplicate

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     
     <!-- Package Metadata -->
-    <Version>2.1.0-beta.5</Version>
+    <Version>2.1.0-beta.6</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-nuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>

--- a/Source/TimeWarp.Nuru.Parsing/Parsing/Compiler/RouteCompiler.cs
+++ b/Source/TimeWarp.Nuru.Parsing/Parsing/Compiler/RouteCompiler.cs
@@ -97,6 +97,14 @@ internal sealed class RouteCompiler : SyntaxVisitor<object?>
     bool expectsValue = option.Parameter is not null;
     string? valueParameterName = option.Parameter?.Name;
 
+    // For boolean options (no parameter), use the option name as the parameter name
+    if (valueParameterName is null && !expectsValue)
+    {
+      // Extract the option name from the syntax (remove leading dashes)
+      valueParameterName = option.LongForm ?? option.ShortForm;
+      NuruLogger.Parser.Debug($"Setting boolean option parameter name to: '{valueParameterName}'");
+    }
+
     if (option.Parameter is not null)
     {
       if (option.Parameter.IsCatchAll)

--- a/Tests/SingleFileTests/Routing/test-boolean-option.cs
+++ b/Tests/SingleFileTests/Routing/test-boolean-option.cs
@@ -1,0 +1,18 @@
+#!/usr/bin/dotnet --
+// test-boolean-option.cs - Test boolean option binding
+#:project ../../../Source/TimeWarp.Nuru/TimeWarp.Nuru.csproj
+
+using TimeWarp.Nuru;
+using static System.Console;
+
+// Enable more logging
+Environment.SetEnvironmentVariable("NURU_LOG_MATCHER", "trace");
+Environment.SetEnvironmentVariable("NURU_LOG_BINDER", "trace");
+Environment.SetEnvironmentVariable("NURU_LOG_PARSER", "debug");
+
+// Test boolean option binding
+NuruApp app = new NuruAppBuilder()
+    .AddRoute("sync --all", (bool all) => WriteLine($"Sync with --all = {all}"))
+    .Build();
+
+return await app.RunAsync(args).ConfigureAwait(false);


### PR DESCRIPTION
## Summary

After an epic debugging session, we discovered and fixed two critical issues:

1. **Boolean option binding was broken** - Boolean options (like `--all`) weren't getting their parameter names set, causing "No value provided for required parameter" errors
2. **Source-only packages were being published to NuGet** - The CI/CD was using a wildcard `*.nupkg` that accidentally published the internal TimeWarp.Nuru.Parsing package

## The Investigation Journey

The debugging revealed several important discoveries:
- .NET single-file scripts cache compiled output in `~/.local/share/dotnet/runfile/`
- Source-only NuGet packages were being pulled from nuget.org instead of local builds
- The CI/CD wildcard pattern was publishing ALL packages instead of just the intended ones

## Changes

- ✅ Fixed boolean option parameter binding in `RouteCompiler.cs`
- ✅ Updated CI/CD to explicitly publish only `TimeWarp.Nuru` and `TimeWarp.Nuru.Analyzers`
- ✅ Bumped version to 2.1.0-beta.6 to avoid the contaminated beta.5 version on nuget.org
- ✅ Added test case for boolean option binding

## Test Plan

- [x] Verified boolean option binding works with test script
- [x] Confirmed CI/CD will only publish intended packages
- [ ] Need to unlist TimeWarp.Nuru.Parsing beta.5 from nuget.org

## Breaking Changes

None - this is a bug fix that restores intended functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)