### PR TITLE
fix: CI/CD workflow version extraction and manual trigger

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -21,6 +21,12 @@ on:
       - '.github/workflows/**'
   release:
     types: [published] # Triggered when a release is published via GitHub Releases UI or gh CLI
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 2.1.0-beta.6)'
+        required: false
+        type: string
 
 jobs:
   build-and-publish:
@@ -53,11 +59,16 @@ jobs:
         run: dotnet ${{ github.workspace }}/Scripts/CheckVersion.cs
 
       - name: Publish to NuGet.org (Releases only)
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.version != '')
         run: |
-          # Extract version from release tag (remove 'v' prefix if present)
-          VERSION="${{ github.event.release.tag_name }}"
-          VERSION="${VERSION#v}"
+          # Get version from either release tag or manual input
+          if [ "${{ github.event_name }}" == "release" ]; then
+            VERSION="${{ github.event.release.tag_name }}"
+            VERSION="${VERSION#v}"  # Remove 'v' prefix if present
+          else
+            VERSION="${{ github.event.inputs.version }}"
+          fi
+          
           echo "Publishing version: $VERSION"
           
           dotnet nuget push LocalNuGetFeed/TimeWarp.Nuru.$VERSION.nupkg \

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -55,11 +55,16 @@ jobs:
       - name: Publish to NuGet.org (Releases only)
         if: github.event_name == 'release'
         run: |
-          dotnet nuget push LocalNuGetFeed/TimeWarp.Nuru.${{ env.VERSION }}.nupkg \
+          # Extract version from release tag (remove 'v' prefix if present)
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+          echo "Publishing version: $VERSION"
+          
+          dotnet nuget push LocalNuGetFeed/TimeWarp.Nuru.$VERSION.nupkg \
             --api-key ${{ secrets.NUGET_API_KEY }} \
             --source https://api.nuget.org/v3/index.json \
             --skip-duplicate
-          dotnet nuget push LocalNuGetFeed/TimeWarp.Nuru.Analyzers.${{ env.VERSION }}.nupkg \
+          dotnet nuget push LocalNuGetFeed/TimeWarp.Nuru.Analyzers.$VERSION.nupkg \
             --api-key ${{ secrets.NUGET_API_KEY }} \
             --source https://api.nuget.org/v3/index.json \
             --skip-duplicate


### PR DESCRIPTION
## Summary

Fixed CI/CD workflow issues discovered during beta.6 release attempt:

1. **Version extraction** - The workflow was using `${{ env.VERSION }}` which was never set, causing publish to fail
2. **Manual trigger** - Added `workflow_dispatch` with version input to allow manual re-runs

## Changes

- Extract version from `github.event.release.tag_name` for release events
- Added `workflow_dispatch` trigger with optional version input
- Publish step now handles both release events and manual triggers
- Version can come from either release tag or manual input

## Test Plan

- [x] Workflow improvements tested locally
- [ ] Will be validated with next release

🤖 Generated with [Claude Code](https://claude.ai/code)