### PR TITLE
fix: Add TimeWarp.Nuru.Logging to CI/CD and bump to beta.8

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -79,6 +79,10 @@ jobs:
             --api-key ${{ secrets.NUGET_API_KEY }} \
             --source https://api.nuget.org/v3/index.json \
             --skip-duplicate
+          dotnet nuget push LocalNuGetFeed/TimeWarp.Nuru.Logging.$VERSION.nupkg \
+            --api-key ${{ secrets.NUGET_API_KEY }} \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate
         env:
           DOTNET_NUGET_SIGNATURE_VERIFICATION: false
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     
     <!-- Package Metadata -->
-    <Version>2.1.0-beta.7</Version>
+    <Version>2.1.0-beta.8</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-nuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- Fixed CI/CD workflow to include TimeWarp.Nuru.Logging package in NuGet publishing
- Bumped version to 2.1.0-beta.8 for new release

## Problem
The TimeWarp.Nuru.Logging package was not being published to NuGet because it wasn't included in the CI/CD workflow.

## Solution
Added the Logging package to the publish step in the GitHub Actions workflow.

🤖 Generated with [Claude Code](https://claude.ai/code)