### PR TITLE
fix(scripts): Update CheckVersion.cs to use preview features and CaptureAsync API

### DIFF
--- a/Scripts/CheckVersion.cs
+++ b/Scripts/CheckVersion.cs
@@ -1,4 +1,5 @@
 #!/usr/bin/dotnet --
+#:property EnablePreviewFeatures=true
 // CheckVersion.cs - Check if NuGet packages are already published
 
 using System.Xml.Linq;
@@ -28,16 +29,15 @@ foreach (string package in packages)
 {
     WriteLine($"\nChecking {package}...");
 
-    CommandResult searchResult = DotNet.PackageSearch(package)
+    CommandOutput result = await DotNet.PackageSearch(package)
         .WithExactMatch()
         .WithPrerelease()
         .WithSource("https://api.nuget.org/v3/index.json")
-        .Build();
-
-    ExecutionResult result = await searchResult.ExecuteAsync();
+        .Build()
+        .CaptureAsync();
 
     // Check if the version appears in the output
-    if (result.StandardOutput.Contains($"| {version} |", StringComparison.Ordinal))
+    if (result.Stdout.Contains($"| {version} |", StringComparison.Ordinal))
     {
         WriteLine($"⚠️  WARNING: {package} {version} is already published to NuGet.org");
         anyPublished = true;


### PR DESCRIPTION
## Summary
- Fixed CheckVersion.cs script to work with latest Amuru API
- Script now correctly checks if NuGet packages are already published before release

## Changes
- Added `EnablePreviewFeatures` property to opt into preview features (fixes CA2252 warnings)
- Updated to use `CaptureAsync()` instead of `ExecuteAsync()` for capturing command output
- Fixed return type from `ExecutionResult` to `CommandOutput`
- Changed `StandardOutput` property to `Stdout` to match Amuru API

## Test Plan
- [x] Tested script locally - successfully checks all 4 packages
- [x] Verified script correctly reports packages not yet published
- [x] Script runs without errors or warnings

🤖 Generated with [Claude Code](https://claude.ai/code)