### PR TITLE
fix(tests): Make test script discover target framework dynamically

### DIFF
--- a/Tests/test-both-versions.sh
+++ b/Tests/test-both-versions.sh
@@ -182,10 +182,19 @@ echo ""
 echo "Running tests..."
 echo ""
 
+# Discover target framework from Directory.Build.props
+TARGET_FRAMEWORK=$(grep -oP '<TargetFramework>\K[^<]+' Directory.Build.props | head -1)
+if [ -z "$TARGET_FRAMEWORK" ]; then
+    echo -e "${RED}Could not determine target framework from Directory.Build.props${NC}"
+    exit 1
+fi
+echo "Using target framework: $TARGET_FRAMEWORK"
+echo ""
+
 # Test Delegate JIT
 echo -e "${BLUE}1. Delegate-based routing (JIT)${NC}"
 echo "================================="
-EXECUTABLE="./Tests/TimeWarp.Nuru.TestApp.Delegates/bin/Release/net9.0/TimeWarp.Nuru.TestApp.Delegates"
+EXECUTABLE="./Tests/TimeWarp.Nuru.TestApp.Delegates/bin/Release/$TARGET_FRAMEWORK/TimeWarp.Nuru.TestApp.Delegates"
 START_TIME=$(date +%s.%N)
 run_all_tests
 END_TIME=$(date +%s.%N)
@@ -198,7 +207,7 @@ echo "Execution time: ${DELEGATE_JIT_TIME}s"
 echo ""
 echo -e "${BLUE}2. Mediator-based routing (JIT)${NC}"
 echo "================================="
-EXECUTABLE="./Tests/TimeWarp.Nuru.TestApp.Mediator/bin/Release/net9.0/TimeWarp.Nuru.TestApp.Mediator"
+EXECUTABLE="./Tests/TimeWarp.Nuru.TestApp.Mediator/bin/Release/$TARGET_FRAMEWORK/TimeWarp.Nuru.TestApp.Mediator"
 START_TIME=$(date +%s.%N)
 run_all_tests
 END_TIME=$(date +%s.%N)


### PR DESCRIPTION
## Summary
- Fixed test script to dynamically discover target framework from Directory.Build.props
- Tests now work with any .NET version without hardcoding

## Changes
- Modified `test-both-versions.sh` to read TargetFramework from Directory.Build.props
- Prevents test failures when upgrading between .NET versions (e.g., net9.0 to net10.0)
- All 44 tests now passing for both Delegate and Mediator implementations

## Test Results
```
Test Results:
Implementation            | Tests      | Execution Time
------------------------- | ---------- | ---------------
Delegate (JIT)            | 44/44      | 2.826773134s
Mediator (JIT)            | 44/44      | 4.312721735s
Delegate (AOT)            | 44/44      | .379852223s
Mediator (AOT)            | 44/44      | .664492424s
```

## Why This Matters
- Prevents CI/CD failures when switching .NET versions
- Makes the test infrastructure more maintainable
- Supports upcoming .NET 9 release in November while developing with .NET 10 preview

🤖 Generated with [Claude Code](https://claude.ai/code)