### PR TITLE
chore: bump version to 2.1.0-beta.11

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     
     <!-- Package Metadata -->
-    <Version>2.1.0-beta.10</Version>
+    <Version>2.1.0-beta.11</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-nuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- Bumps version from 2.1.0-beta.10 to 2.1.0-beta.11 in Directory.Build.props

## Test plan
- [x] Version update is isolated to Directory.Build.props
- [ ] Build and tests pass with new version

🤖 Generated with [Claude Code](https://claude.ai/code)