### PR TITLE
fix: Add GeneratePackageOnBuild to MCP project

### DIFF
--- a/Source/TimeWarp.Nuru.Mcp/TimeWarp.Nuru.Mcp.csproj
+++ b/Source/TimeWarp.Nuru.Mcp/TimeWarp.Nuru.Mcp.csproj
@@ -6,6 +6,7 @@
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 
     <!-- Set up the NuGet package to be an MCP server -->
     <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
## Summary
- Adds `GeneratePackageOnBuild` property to TimeWarp.Nuru.Mcp project to ensure the package is generated during CI/CD builds

## Problem
The v2.1.0-beta.11 release failed because the MCP server package wasn't being created. All other projects have `GeneratePackageOnBuild=true` which automatically creates packages during build, but the MCP project was missing this property.

## Solution  
Added `<GeneratePackageOnBuild>true</GeneratePackageOnBuild>` to match the configuration of other projects in the solution.

## Test plan
- [x] Verified all other projects have this property
- [ ] Build locally generates the MCP package
- [ ] CI/CD workflow will successfully publish all 4 packages

🤖 Generated with [Claude Code](https://claude.ai/code)