### PR TITLE
fix: Add PackageOutputPath to MCP project

### DIFF
--- a/Source/TimeWarp.Nuru.Mcp/TimeWarp.Nuru.Mcp.csproj
+++ b/Source/TimeWarp.Nuru.Mcp/TimeWarp.Nuru.Mcp.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageOutputPath>../../LocalNuGetFeed</PackageOutputPath>
 
     <!-- Set up the NuGet package to be an MCP server -->
     <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
## Summary
- Adds `PackageOutputPath` property to TimeWarp.Nuru.Mcp project to ensure the package outputs to LocalNuGetFeed directory

## Problem
The MCP package was being generated during build but was placed in the project's bin/Release folder instead of LocalNuGetFeed, causing the CI/CD workflow to fail when trying to publish it.

## Solution  
Added `<PackageOutputPath>../../LocalNuGetFeed</PackageOutputPath>` to match the configuration of other projects in the solution.

## Test plan
- [x] Verified all other projects have this property
- [x] Build locally now generates the MCP package in LocalNuGetFeed
- [ ] CI/CD workflow will successfully find and publish all 4 packages

🤖 Generated with [Claude Code](https://claude.ai/code)