### PR TITLE
chore: bump version to 2.1.0-beta.14 and update Roslynator to 4.14.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,7 +33,7 @@
 
   <!-- Default package metadata (can be overridden in individual projects) -->
   <PropertyGroup Label="Package Metadata">
-    <Version>2.1.0-beta.13</Version>
+    <Version>2.1.0-beta.14</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-nuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,9 +45,9 @@
     <!-- MCP Server packages -->
     <PackageVersion Include="ModelContextProtocol" Version="0.3.0-preview.4" />
     <!-- Analyzers -->
-    <PackageVersion Include="Roslynator.Analyzers" Version="4.14.0" />
-    <PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.14.0" />
-    <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="4.14.0" />
+    <PackageVersion Include="Roslynator.Analyzers" Version="4.14.1" />
+    <PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.14.1" />
+    <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="4.14.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.14.0" />
     <!-- Roslyn Analyzer Dependencies -->


### PR DESCRIPTION
## Summary

This PR includes:
- Version bump to 2.1.0-beta.14
- Roslynator analyzers updated from 4.14.0 to 4.14.1

## Changes

- Updated version in [Directory.Build.props](Directory.Build.props#L36)
- Updated Roslynator analyzer packages in [Directory.Packages.props](Directory.Packages.props#L48-L50)

## Test plan

- ✅ CI/CD workflow will run build and tests
- ✅ Version incremented correctly
- ✅ Analyzer updates are patch version only (no breaking changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)