### PR TITLE
fix: add root config files to CI/CD workflow paths filter

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,6 +10,8 @@ on:
       - 'Tests/**'
       - 'Scripts/**'
       - '.github/workflows/**'
+      - 'Directory.Build.props'
+      - 'Directory.Packages.props'
   pull_request:
     branches:
       - master
@@ -19,6 +21,8 @@ on:
       - 'Tests/**'
       - 'Scripts/**'
       - '.github/workflows/**'
+      - 'Directory.Build.props'
+      - 'Directory.Packages.props'
   release:
     types: [published] # Triggered when a release is published via GitHub Releases UI or gh CLI
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Fixes CI/CD workflow so that changes to root configuration files trigger validation runs.

## Problem

PR #48 (version bump and Roslynator update) didn't trigger any CI workflow runs because it only modified `Directory.Build.props` and `Directory.Packages.props`, which weren't included in the workflow's paths filter.

## Solution

Added both root configuration files to the paths filter:
- `Directory.Build.props` - Contains version, metadata, and MSBuild settings
- `Directory.Packages.props` - Contains all package version definitions

## Impact

Now the workflow will trigger on:
- ✅ Version bumps
- ✅ Package dependency updates
- ✅ MSBuild property changes
- ✅ All previously covered paths (Source/, Tests/, Scripts/, etc.)

## Test plan

- This PR itself modifies `.github/workflows/ci-cd.yml`, which is already in the paths filter, so it will trigger a workflow run
- Future PRs modifying `Directory.Build.props` or `Directory.Packages.props` will now trigger validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)