### PR TITLE
fix(scripts): update CheckVersion.cs path after build refactoring

### DIFF
--- a/Scripts/CheckVersion.cs
+++ b/Scripts/CheckVersion.cs
@@ -8,14 +8,14 @@ using System.Xml.Linq;
 string scriptDir = (AppContext.GetData("EntryPointFileDirectoryPath") as string)!;
 Directory.SetCurrentDirectory(scriptDir);
 
-// Read version from Directory.Build.props
-string propsPath = "../Directory.Build.props";
+// Read version from Source/Directory.Build.props
+string propsPath = "../Source/Directory.Build.props";
 var doc = XDocument.Load(propsPath);
 string? version = doc.Descendants("Version").FirstOrDefault()?.Value;
 
 if (string.IsNullOrEmpty(version))
 {
-    WriteLine("❌ Could not find version in Directory.Build.props");
+    WriteLine("❌ Could not find version in Source/Directory.Build.props");
     Environment.Exit(1);
 }
 
@@ -50,7 +50,7 @@ foreach (string package in packages)
 
 if (anyPublished)
 {
-    WriteLine("\n❌ One or more packages are already published. Please increment the version in Directory.Build.props");
+    WriteLine("\n❌ One or more packages are already published. Please increment the version in Source/Directory.Build.props");
     Environment.Exit(1);
 }
 


### PR DESCRIPTION
## Problem

CI is failing at the "Check if version already published" step:
```
❌ Could not find version in Directory.Build.props
Error: Process completed with exit code 1.
```

## Root Cause

Version property was moved from root `Directory.Build.props` to `Source/Directory.Build.props` as part of the build configuration refactoring (only source projects get versioned for NuGet packaging), but `CheckVersion.cs` wasn't updated.

## Solution

Updated [Scripts/CheckVersion.cs](Scripts/CheckVersion.cs):
- Read version from `../Source/Directory.Build.props` instead of `../Directory.Build.props`
- Updated error messages to reference correct file path

## Testing

```bash
$ ./Scripts/CheckVersion.cs
Checking if packages with version 2.1.0-beta.16 are already published on NuGet.org...
✅ All packages are ready to publish!
```

This fixes the CI failure and allows the release workflow to complete successfully.