### PR TITLE
chore: bump version to 2.1.0-beta.18

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -4,7 +4,7 @@
 
   <!-- Default package metadata (can be overridden in individual projects) -->
   <PropertyGroup Label="Package Metadata">
-    <Version>2.1.0-beta.17</Version>
+    <Version>2.1.0-beta.18</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-nuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>


### PR DESCRIPTION
## Summary

Version bump to `2.1.0-beta.18` for release.

## Changes in This Release

### MCP Test Fixes (52/52 tests passing ✅)
1. **mcp-03-route-validation.cs** - Fixed exception handling to catch `PatternException`
2. **mcp-04-handler-generation.cs** - Fixed invalid pattern test expectations
3. **mcp-05-error-documentation.cs** - Fixed GitHub documentation path capitalization

### Performance Improvements
- Added `sealed` modifier to all command and handler classes across samples and documentation

### Infrastructure
- Embedded `SyntaxExamples.cs` as assembly resource for reliable distribution

## Previous Version
- 2.1.0-beta.17

## Files Changed
- `Source/Directory.Build.props` - Version bump only

🤖 Generated with [Claude Code](https://claude.com/claude-code)