### PR TITLE
fix(build): disable symbol packages with embedded debug symbols

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -4,7 +4,7 @@
 
   <!-- Default package metadata (can be overridden in individual projects) -->
   <PropertyGroup Label="Package Metadata">
-    <Version>2.1.0-beta.18</Version>
+    <Version>2.1.0-beta.19</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-nuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>
@@ -21,8 +21,7 @@
   <PropertyGroup Label="Source Link Settings">
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <IncludeSymbols>false</IncludeSymbols>
     <DebugType>embedded</DebugType>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

Fixes the CI/CD build failure where NuGet was rejecting empty `.snupkg` symbol packages.

## Problem

The build was configured with:
- `DebugType=embedded` - Embeds debug symbols directly in the DLL
- `IncludeSymbols=true` - Creates a separate `.snupkg` symbol package
- `SymbolPackageFormat=snupkg` - Format for the symbol package

This combination creates an **empty** `.snupkg` file (because there are no separate .pdb files when using embedded symbols), which NuGet rejects with:

```
error: Response status code does not indicate success: 400 (The package does not contain any symbol (.pdb) files.).
```

## Solution

- Changed `IncludeSymbols` from `true` to `false`
- Removed `SymbolPackageFormat=snupkg` (not needed)
- Kept `DebugType=embedded` (this is the right approach)

**Result**: No more empty .snupkg files, CI/CD will pass, and users can **still debug** through the code because symbols are embedded in the DLL.

## Version Bump

Bumped version from `2.1.0-beta.18` to `2.1.0-beta.19` since beta.18 was already published to NuGet.

## Files Changed

- `Source/Directory.Build.props` - Symbol package config and version

🤖 Generated with [Claude Code](https://claude.com/claude-code)