### PR TITLE
docs: remove broken roadmap link from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -173,7 +173,6 @@ We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 **For Contributors:**
 - **[Developer Documentation](documentation/developer/overview.md)** - Architecture and design
 - **[Standards](documentation/developer/standards/)** - Coding conventions
-- **[Roadmap](documentation/developer/roadmap/)** - Future plans
 
 ## 📄 License
 


### PR DESCRIPTION
## Summary

Quick documentation fix to remove a broken roadmap link from the readme's Contributing section.

## What Changed

Removed the non-existent roadmap link from the Contributors section:

**Before:**
```markdown
**For Contributors:**
- **[Developer Documentation](documentation/developer/overview.md)** - Architecture and design
- **[Standards](documentation/developer/standards/)** - Coding conventions
- **[Roadmap](documentation/developer/roadmap/)** - Future plans
```

**After:**
```markdown
**For Contributors:**
- **[Developer Documentation](documentation/developer/overview.md)** - Architecture and design
- **[Standards](documentation/developer/standards/)** - Coding conventions
```

## Why This Matters

- Broken links damage user experience and project credibility
- Contributors should only see links to resources that actually exist
- Cleaner, more focused contributor documentation

## Files Changed

- `readme.md` - Removed roadmap link (line 176)

## Type

- [x] Documentation fix
- [ ] Bug fix
- [ ] Feature
- [ ] Breaking change

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)