### PR TITLE
fix(samples): Remove false pipeline distinction from unified-middleware sample

### DIFF
--- a/kanban/done/113-fix-unified-middleware-sample-false-distinction.md
+++ b/kanban/done/113-fix-unified-middleware-sample-false-distinction.md
@@ -21,16 +21,16 @@ The redundant `DelegateLoggingBehavior` and `DelegatePerformanceBehavior` classe
 ## Checklist
 
 ### Implementation
-- [ ] Remove `DelegateLoggingBehavior` class
-- [ ] Remove `DelegatePerformanceBehavior` class
-- [ ] Update `ConfigureServices` to only register open generic behaviors
-- [ ] Update header comments to explain unified pipeline correctly
-- [ ] Update `TRY THESE COMMANDS` section to show unified logging output
-- [ ] Verify sample compiles and runs correctly
+- [x] Remove `DelegateLoggingBehavior` class
+- [x] Remove `DelegatePerformanceBehavior` class
+- [x] Update `ConfigureServices` to only register open generic behaviors
+- [x] Update header comments to explain unified pipeline correctly
+- [x] Update `TRY THESE COMMANDS` section to show unified logging output
+- [x] Verify sample compiles and runs correctly
 
 ### Documentation
-- [ ] Ensure comments explain that `DelegateRequest` is just another `IRequest<T>`
-- [ ] Clarify that open generics catch ALL request types
+- [x] Ensure comments explain that `DelegateRequest` is just another `IRequest<T>`
+- [x] Clarify that open generics catch ALL request types
 
 ## Notes
 

--- a/samples/unified-middleware/unified-middleware.cs
+++ b/samples/unified-middleware/unified-middleware.cs
@@ -5,27 +5,29 @@
 #:package Mediator.SourceGenerator
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// UNIFIED MIDDLEWARE - DELEGATE + MEDIATOR ROUTES EXAMPLE
+// UNIFIED MIDDLEWARE - ONE PIPELINE FOR ALL ROUTES
 // ═══════════════════════════════════════════════════════════════════════════════
 //
-// This sample demonstrates that pipeline behaviors apply uniformly to BOTH:
-// - Delegate routes (simple lambdas)
-// - Mediator routes (IRequest commands)
+// KEY INSIGHT: There is ONE Mediator pipeline, not two separate pipelines.
+//
+// Delegate routes are wrapped in DelegateRequest (which implements IRequest<T>)
+// and sent through IMediator.Send(). This means open generic behaviors like
+// LoggingBehavior<,> automatically apply to ALL requests:
+//   - DelegateRequest (for delegate routes)
+//   - EchoCommand, SlowCommand, etc. (for mediator routes)
 //
 // REQUIRED PACKAGES:
 //   #:package Mediator.Abstractions    - Interfaces (IRequest, IRequestHandler, IPipelineBehavior)
 //   #:package Mediator.SourceGenerator - Generates AddMediator() in YOUR assembly
 //
-// HOW UNIFIED MIDDLEWARE WORKS:
-//   When pipeline behaviors are registered for DelegateRequest/DelegateResponse,
-//   delegate routes are wrapped in DelegateRequest and sent through IMediator.Send().
-//   This ensures cross-cutting concerns apply consistently regardless of route type.
-//
 // TRY THESE COMMANDS:
-//   ./unified-middleware.cs add 5 3        # Delegate route - shows pipeline logging
-//   ./unified-middleware.cs echo "hello"   # Mediator route - shows pipeline logging
-//   ./unified-middleware.cs slow 600       # Mediator route - triggers slow warning
-//   ./unified-middleware.cs multiply 4 7   # Delegate route - shows pipeline logging
+//   ./unified-middleware.cs add 5 3        # Shows "[PIPELINE] Handling DelegateRequest"
+//   ./unified-middleware.cs echo "hello"   # Shows "[PIPELINE] Handling EchoCommand"
+//   ./unified-middleware.cs slow 600       # Shows "[PIPELINE] Handling SlowCommand" + slow warning
+//   ./unified-middleware.cs multiply 4 7   # Shows "[PIPELINE] Handling DelegateRequest"
+//
+// NOTICE: The same LoggingBehavior<,> handles both DelegateRequest and EchoCommand.
+// No separate "delegate behaviors" are needed - open generics catch everything!
 //
 // COMMON ERROR:
 //   "No service for type 'Mediator.IMediator' has been registered"
@@ -42,7 +44,7 @@ using static System.Console;
 NuruCoreApp app = NuruApp.CreateBuilder(args)
   .ConfigureServices(ConfigureServices)
   // =========================================================================
-  // DELEGATE ROUTES - These now receive pipeline behaviors too!
+  // DELEGATE ROUTES - Wrapped in DelegateRequest, flows through same pipeline
   // =========================================================================
   .Map
   (
@@ -73,7 +75,7 @@ NuruCoreApp app = NuruApp.CreateBuilder(args)
     description: "Greet someone (delegate route with pipeline)"
   )
   // =========================================================================
-  // MEDIATOR ROUTES - These have pipeline behaviors as usual
+  // MEDIATOR ROUTES - Specific IRequest types, flows through same pipeline
   // =========================================================================
   .Map<EchoCommand>
   (
@@ -91,126 +93,30 @@ return await app.RunAsync(args);
 
 static void ConfigureServices(IServiceCollection services)
 {
-  // Register Mediator with pipeline behaviors using open generics.
+  // Register Mediator with open generic pipeline behaviors.
+  // These apply to ALL IRequest<T> types including DelegateRequest.
   // Behaviors execute in array order: first = outermost (wraps everything).
   services.AddMediator(options =>
   {
     options.PipelineBehaviors =
     [
-      typeof(LoggingBehavior<,>),            // Logs entry/exit for Mediator commands
-      typeof(PerformanceBehavior<,>),        // Warns on slow Mediator commands
-      typeof(DelegateLoggingBehavior),       // Logs entry/exit for delegate routes
-      typeof(DelegatePerformanceBehavior)    // Warns on slow delegate routes
+      typeof(LoggingBehavior<,>),      // Applies to ALL requests (DelegateRequest, EchoCommand, etc.)
+      typeof(PerformanceBehavior<,>),  // Applies to ALL requests (DelegateRequest, EchoCommand, etc.)
     ];
   });
 }
 
 // =============================================================================
-// PIPELINE BEHAVIORS FOR DELEGATE ROUTES
+// OPEN GENERIC PIPELINE BEHAVIORS - Apply to ALL IRequest<T> types
+// =============================================================================
+// DelegateRequest implements IRequest<DelegateResponse>, so these behaviors
+// automatically apply to delegate routes without any special configuration.
 // =============================================================================
 
 /// <summary>
-/// Logging behavior for delegate routes.
-/// This demonstrates unified middleware - same pattern as Mediator behaviors.
-/// </summary>
-public sealed class DelegateLoggingBehavior : IPipelineBehavior<DelegateRequest, DelegateResponse>
-{
-  private readonly ILogger<DelegateLoggingBehavior> Logger;
-  private readonly RouteExecutionContext ExecutionContext;
-
-  public DelegateLoggingBehavior(ILogger<DelegateLoggingBehavior> logger, RouteExecutionContext executionContext)
-  {
-    Logger = logger;
-    ExecutionContext = executionContext;
-  }
-
-  public async ValueTask<DelegateResponse> Handle
-  (
-    DelegateRequest message,
-    MessageHandlerDelegate<DelegateRequest, DelegateResponse> next,
-    CancellationToken cancellationToken
-  )
-  {
-    // Access route metadata from the execution context
-    Logger.LogInformation
-    (
-      "[DELEGATE PIPELINE] Handling route: {RoutePattern}",
-      ExecutionContext.RoutePattern
-    );
-
-    try
-    {
-      DelegateResponse response = await next(message, cancellationToken);
-      Logger.LogInformation("[DELEGATE PIPELINE] Completed route: {RoutePattern}", ExecutionContext.RoutePattern);
-      return response;
-    }
-    catch (Exception ex)
-    {
-      Logger.LogError(ex, "[DELEGATE PIPELINE] Error handling route: {RoutePattern}", ExecutionContext.RoutePattern);
-      throw;
-    }
-  }
-}
-
-/// <summary>
-/// Performance behavior for delegate routes.
-/// Warns when delegate execution exceeds threshold.
-/// </summary>
-public sealed class DelegatePerformanceBehavior : IPipelineBehavior<DelegateRequest, DelegateResponse>
-{
-  private readonly ILogger<DelegatePerformanceBehavior> Logger;
-  private readonly RouteExecutionContext ExecutionContext;
-  private const int SlowThresholdMs = 500;
-
-  public DelegatePerformanceBehavior(ILogger<DelegatePerformanceBehavior> logger, RouteExecutionContext executionContext)
-  {
-    Logger = logger;
-    ExecutionContext = executionContext;
-  }
-
-  public async ValueTask<DelegateResponse> Handle
-  (
-    DelegateRequest message,
-    MessageHandlerDelegate<DelegateRequest, DelegateResponse> next,
-    CancellationToken cancellationToken
-  )
-  {
-    Stopwatch stopwatch = Stopwatch.StartNew();
-
-    DelegateResponse response = await next(message, cancellationToken);
-
-    stopwatch.Stop();
-
-    if (stopwatch.ElapsedMilliseconds > SlowThresholdMs)
-    {
-      Logger.LogWarning
-      (
-        "[DELEGATE PERFORMANCE] Route {RoutePattern} took {ElapsedMs}ms (threshold: {ThresholdMs}ms)",
-        ExecutionContext.RoutePattern,
-        stopwatch.ElapsedMilliseconds,
-        SlowThresholdMs
-      );
-    }
-    else
-    {
-      Logger.LogInformation
-      (
-        "[DELEGATE PERFORMANCE] Route {RoutePattern} completed in {ElapsedMs}ms",
-        ExecutionContext.RoutePattern,
-        stopwatch.ElapsedMilliseconds
-      );
-    }
-
-    return response;
-  }
-}
-
-// =============================================================================
-// PIPELINE BEHAVIORS FOR MEDIATOR ROUTES (same as before)
-// =============================================================================
-
-/// <summary>
-/// Logging behavior for Mediator commands.
+/// Logging behavior that applies to ALL request types.
+/// For delegate routes, TMessage is DelegateRequest.
+/// For mediator routes, TMessage is the specific command type (e.g., EchoCommand).
 /// </summary>
 public sealed class LoggingBehavior<TMessage, TResponse> : IPipelineBehavior<TMessage, TResponse>
   where TMessage : IMessage
@@ -230,24 +136,25 @@ public sealed class LoggingBehavior<TMessage, TResponse> : IPipelineBehavior<TMe
   )
   {
     string requestName = typeof(TMessage).Name;
-    Logger.LogInformation("[MEDIATOR PIPELINE] Handling {RequestName}", requestName);
+    Logger.LogInformation("[PIPELINE] Handling {RequestName}", requestName);
 
     try
     {
       TResponse response = await next(message, cancellationToken);
-      Logger.LogInformation("[MEDIATOR PIPELINE] Completed {RequestName}", requestName);
+      Logger.LogInformation("[PIPELINE] Completed {RequestName}", requestName);
       return response;
     }
     catch (Exception ex)
     {
-      Logger.LogError(ex, "[MEDIATOR PIPELINE] Error handling {RequestName}", requestName);
+      Logger.LogError(ex, "[PIPELINE] Error handling {RequestName}", requestName);
       throw;
     }
   }
 }
 
 /// <summary>
-/// Performance behavior for Mediator commands.
+/// Performance behavior that applies to ALL request types.
+/// Warns when any request (delegate or mediator) exceeds threshold.
 /// </summary>
 public sealed class PerformanceBehavior<TMessage, TResponse> : IPipelineBehavior<TMessage, TResponse>
   where TMessage : IMessage
@@ -279,7 +186,7 @@ public sealed class PerformanceBehavior<TMessage, TResponse> : IPipelineBehavior
     {
       Logger.LogWarning
       (
-        "[MEDIATOR PERFORMANCE] {RequestName} took {ElapsedMs}ms (threshold: {ThresholdMs}ms)",
+        "[PERFORMANCE] {RequestName} took {ElapsedMs}ms (threshold: {ThresholdMs}ms)",
         requestName,
         stopwatch.ElapsedMilliseconds,
         SlowThresholdMs
@@ -289,7 +196,7 @@ public sealed class PerformanceBehavior<TMessage, TResponse> : IPipelineBehavior
     {
       Logger.LogInformation
       (
-        "[MEDIATOR PERFORMANCE] {RequestName} completed in {ElapsedMs}ms",
+        "[PERFORMANCE] {RequestName} completed in {ElapsedMs}ms",
         requestName,
         stopwatch.ElapsedMilliseconds
       );


### PR DESCRIPTION
## Summary

- Fix misleading unified-middleware sample that suggested two separate pipelines exist (`[DELEGATE PIPELINE]` vs `[MEDIATOR PIPELINE]`) when in reality there is ONE unified Mediator pipeline
- Remove redundant `DelegateLoggingBehavior` and `DelegatePerformanceBehavior` classes that confused users into thinking separate behaviors are needed for delegate routes
- Update comments and labels to correctly teach that `DelegateRequest` implements `IRequest<DelegateResponse>` and flows through the same pipeline as all other request types

The sample now correctly demonstrates that open generic behaviors like `LoggingBehavior<,>` automatically apply to ALL requests - both delegate routes (showing `DelegateRequest`) and mediator routes (showing `EchoCommand`, etc.).