### PR TITLE
chore: bump version to 3.0.0-beta.18

### DIFF
--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -4,7 +4,7 @@
 
   <!-- Default package metadata (can be overridden in individual projects) -->
   <PropertyGroup Label="Package Metadata">
-    <Version>3.0.0-beta.17</Version>
+    <Version>3.0.0-beta.18</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-nuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- Bump version to 3.0.0-beta.18 for release