### PR TITLE
feat(251): convert Terminal to use Builder NuGet package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,6 +23,8 @@
   </ItemGroup>
   <ItemGroup Label="TimeWarp Packages">
     <PackageVersion Include="TimeWarp.Amuru" Version="1.0.0-beta.13" />
+    <PackageVersion Include="TimeWarp.Builder" Version="1.0.0-beta.1" />
+    <PackageVersion Include="TimeWarp.Terminal" Version="1.0.0-beta.1" />
     <PackageVersion Include="TimeWarp.Jaribu" Version="1.0.0-beta.6" />
     <PackageVersion Include="TimeWarp.Build.Tasks" Version="1.0.0" />
     <PackageVersion Include="TimeWarp.OptionsValidation" Version="1.0.0-beta.4" />

--- a/source/timewarp-terminal/timewarp-terminal.csproj
+++ b/source/timewarp-terminal/timewarp-terminal.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../timewarp-builder/timewarp-builder.csproj" />
+    <PackageReference Include="TimeWarp.Builder" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Convert Terminal's `ProjectReference` to `PackageReference` for `TimeWarp.Builder` (now on NuGet at 1.0.0-beta.1)
- Add `TimeWarp.Builder` and `TimeWarp.Terminal` version entries to `Directory.Packages.props`

Part of task 251: Bootstrap independent Builder/Terminal CI pipelines