### PR TITLE
fix: Add timewarp-nuru-build to CI build pipeline (3.0.0-beta.30)

### DIFF
--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -8,7 +8,7 @@
 
   <!-- Default package metadata (can be overridden in individual projects) -->
   <PropertyGroup Label="Package Metadata">
-    <Version>3.0.0-beta.29</Version>
+    <Version>3.0.0-beta.30</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-nuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>

--- a/timewarp-nuru.slnx
+++ b/timewarp-nuru.slnx
@@ -8,6 +8,7 @@
   <Folder Name="/source/">
     <Project Path="source/timewarp-nuru/timewarp-nuru.csproj" />
     <Project Path="source/timewarp-nuru-analyzers/timewarp-nuru-analyzers.csproj" />
+    <Project Path="source/timewarp-nuru-build/timewarp-nuru-build.csproj" />
     <Project Path="source/timewarp-nuru-mcp/timewarp-nuru-mcp.csproj" />
     <Project Path="source/timewarp-nuru-parsing/timewarp-nuru-parsing.csproj" />
     <!-- <Project Path="source/timewarp-nuru-repl/timewarp-nuru-repl.csproj" /> -->

--- a/tools/dev-cli/commands/build-command.cs
+++ b/tools/dev-cli/commands/build-command.cs
@@ -68,9 +68,12 @@ internal sealed class BuildCommand : ICommand<Unit>
       // - timewarp-nuru-repl: Needs NuruApp properties not yet implemented
       // - timewarp-nuru-testapp-delegates: Has catch-all parameter generator bug (#331)
       // - benchmarks/samples: Not needed for CI validation
+      // IMPORTANT: timewarp-nuru-build must be built BEFORE timewarp-nuru because
+      // timewarp-nuru includes its output DLLs in the NuGet package via wildcard.
       string[] projectsToBuild =
       [
         "source/timewarp-nuru-analyzers/timewarp-nuru-analyzers.csproj",
+        "source/timewarp-nuru-build/timewarp-nuru-build.csproj",
         "source/timewarp-nuru-mcp/timewarp-nuru-mcp.csproj",
         "source/timewarp-nuru/timewarp-nuru.csproj"
       ];


### PR DESCRIPTION
## Summary

- Fixes #389: MSBuild task DLL still missing in beta.29 after CI publish
- Root cause: `timewarp-nuru-build` was not in solution or CI build list
- Bump version to 3.0.0-beta.30

## Root Cause

The CI pipeline (`tools/dev-cli/commands/build-command.cs`) was not building `timewarp-nuru-build`:

1. **clean** - `find ... -name bin -exec rm -rf` deletes ALL bin directories including `timewarp-nuru-build/bin`
2. **build** - only built projects in the explicit `projectsToBuild` list (did not include `timewarp-nuru-build`)
3. **pack --no-build** - the wildcard `../timewarp-nuru-build/bin/Release/net10.0/*.dll` found NO files

## Changes

- Add `timewarp-nuru-build` to `timewarp-nuru.slnx`
- Add `timewarp-nuru-build` to `build-command.cs` projectsToBuild array (placed BEFORE `timewarp-nuru`)
- Bump version to 3.0.0-beta.30
- Update kanban task #389 with detailed root cause analysis

## Test plan

- [ ] CI builds successfully
- [ ] Published package contains `build/net10.0/TimeWarp.Nuru.Build.dll`
- [ ] Consumer project builds without MSB4062 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)