### PR TITLE
fix: Handle nullable value types for [Option] properties (GH #146)

### DIFF
--- a/kanban/done/397-fix-source-generator-nullable-value-type-handling-for-options-gh-146.md
+++ b/kanban/done/397-fix-source-generator-nullable-value-type-handling-for-options-gh-146.md
@@ -1,0 +1,35 @@
+# Fix source generator nullable value type handling for Options (GH #146)
+
+## Description
+
+The Nuru source generator doesn't generate type conversion code for nullable value types (`long?`, `int?`, etc.) on `[Option]` properties.
+
+**Current Behavior:** Generator produces direct string assignment for nullable types like `long?`, causing CS0029 compilation error:
+```csharp
+ExcludeInvoiceId = excludeinvoiceid,  // ERROR: Cannot convert string to long?
+```
+
+**Expected Behavior:** Generator should produce TryParse code for nullable value types, similar to non-nullable types:
+```csharp
+long? excludeinvoiceid = null;
+if (__excludeinvoiceid_raw != null)
+{
+    if (long.TryParse(__excludeinvoiceid_raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out long parsed))
+    {
+        excludeinvoiceid = parsed;
+    }
+}
+```
+
+## Checklist
+
+- [ ] Identify where option type conversion is generated in the source generator
+- [ ] Add logic to detect nullable value types (Nullable<T>)
+- [ ] Generate appropriate TryParse code for nullable types
+- [ ] Add tests for nullable option types (long?, int?, bool?, etc.)
+
+## Notes
+
+- Reference: https://github.com/TimeWarpEngineering/timewarp-nuru/issues/146
+- Affected types: `long?`, `int?`, and other nullable value types on Options
+- Non-nullable value types already work correctly with TryParse

--- a/tests/timewarp-nuru-tests/routing/routing-25-nullable-value-type-options.cs
+++ b/tests/timewarp-nuru-tests/routing/routing-25-nullable-value-type-options.cs
@@ -1,0 +1,244 @@
+#!/usr/bin/dotnet --
+
+#if !JARIBU_MULTI
+return await RunAllTests();
+#endif
+
+#pragma warning disable RCS1163 // Unused parameter - expected in negative test cases
+
+namespace TimeWarp.Nuru.Tests.Routing
+{
+
+/// <summary>
+/// Tests for nullable value type options (long?, int?, etc.)
+/// Reproduces GitHub issue #146: Source generator doesn't handle nullable value types for Options
+/// </summary>
+[TestTag("Routing")]
+public class NullableValueTypeOptionTests
+{
+  [ModuleInitializer]
+  internal static void Register() => RegisterTests<NullableValueTypeOptionTests>();
+
+  public static async Task Should_parse_nullable_long_option_with_value()
+  {
+    // Arrange
+    using TestTerminal terminal = new();
+    NuruApp app = NuruApp.CreateBuilder()
+      .UseTerminal(terminal)
+      .Map("test --id {id:long?}")
+      .WithHandler((long? id) => $"id:{id}")
+      .AsCommand()
+      .Done()
+      .Build();
+
+    // Act
+    int exitCode = await app.RunAsync(["test", "--id", "123"]);
+
+    // Assert
+    exitCode.ShouldBe(0);
+    terminal.OutputContains("id:123").ShouldBeTrue();
+
+    await Task.CompletedTask;
+  }
+
+  public static async Task Should_parse_nullable_int_option_with_value()
+  {
+    // Arrange
+    using TestTerminal terminal = new();
+    NuruApp app = NuruApp.CreateBuilder()
+      .UseTerminal(terminal)
+      .Map("test --count {count:int?}")
+      .WithHandler((int? count) => $"count:{count}")
+      .AsCommand()
+      .Done()
+      .Build();
+
+    // Act
+    int exitCode = await app.RunAsync(["test", "--count", "42"]);
+
+    // Assert
+    exitCode.ShouldBe(0);
+    terminal.OutputContains("count:42").ShouldBeTrue();
+
+    await Task.CompletedTask;
+  }
+
+  public static async Task Should_return_null_for_nullable_long_option_without_value()
+  {
+    // Arrange
+    using TestTerminal terminal = new();
+    NuruApp app = NuruApp.CreateBuilder()
+      .UseTerminal(terminal)
+      .Map("test --id? {id:long?}")
+      .WithHandler((long? id) => $"id:{id?.ToString(CultureInfo.InvariantCulture) ?? "null"}")
+      .AsCommand()
+      .Done()
+      .Build();
+
+    // Act
+    int exitCode = await app.RunAsync(["test"]);
+
+    // Assert
+    exitCode.ShouldBe(0);
+    terminal.OutputContains("id:null").ShouldBeTrue();
+
+    await Task.CompletedTask;
+  }
+
+  public static async Task Should_error_on_invalid_nullable_long_option_value()
+  {
+    // Arrange
+    using TestTerminal terminal = new();
+    NuruApp app = NuruApp.CreateBuilder()
+      .UseTerminal(terminal)
+      .Map("test --id {id:long?}")
+      .WithHandler((long? id) => $"id:{id}")
+      .AsCommand()
+      .Done()
+      .Build();
+
+    // Act
+    int exitCode = await app.RunAsync(["test", "--id", "notanumber"]);
+
+    // Assert
+    exitCode.ShouldBe(1);
+    terminal.OutputContains("Error").ShouldBeTrue();
+
+    await Task.CompletedTask;
+  }
+
+  public static async Task Should_parse_nullable_double_option_with_value()
+  {
+    // Arrange
+    using TestTerminal terminal = new();
+    NuruApp app = NuruApp.CreateBuilder()
+      .UseTerminal(terminal)
+      .Map("test --rate {rate:double?}")
+      .WithHandler((double? rate) => $"rate:{rate}")
+      .AsCommand()
+      .Done()
+      .Build();
+
+    // Act
+    int exitCode = await app.RunAsync(["test", "--rate", "3.14"]);
+
+    // Assert
+    exitCode.ShouldBe(0);
+    terminal.OutputContains("rate:3.14").ShouldBeTrue();
+
+    await Task.CompletedTask;
+  }
+
+  public static async Task Should_parse_nullable_bool_option_with_value()
+  {
+    // Arrange
+    using TestTerminal terminal = new();
+    NuruApp app = NuruApp.CreateBuilder()
+      .UseTerminal(terminal)
+      .Map("test --flag {flag:bool?}")
+      .WithHandler((bool? flag) => $"flag:{flag}")
+      .AsCommand()
+      .Done()
+      .Build();
+
+    // Act
+    int exitCode = await app.RunAsync(["test", "--flag", "true"]);
+
+    // Assert
+    exitCode.ShouldBe(0);
+    terminal.OutputContains("flag:True").ShouldBeTrue();
+
+    await Task.CompletedTask;
+  }
+
+  public static async Task Should_return_null_for_nullable_bool_option_without_value()
+  {
+    // Arrange
+    using TestTerminal terminal = new();
+    NuruApp app = NuruApp.CreateBuilder()
+      .UseTerminal(terminal)
+      .Map("test --flag? {flag:bool?}")
+      .WithHandler((bool? flag) => $"flag:{(flag.HasValue ? flag.Value.ToString() : "null")}")
+      .AsCommand()
+      .Done()
+      .Build();
+
+    // Act
+    int exitCode = await app.RunAsync(["test"]);
+
+    // Assert
+    exitCode.ShouldBe(0);
+    terminal.OutputContains("flag:null").ShouldBeTrue();
+
+    await Task.CompletedTask;
+  }
+
+  public static async Task Should_parse_nullable_guid_option_with_value()
+  {
+    // Arrange
+    using TestTerminal terminal = new();
+    NuruApp app = NuruApp.CreateBuilder()
+      .UseTerminal(terminal)
+      .Map("test --guid {guid:guid?}")
+      .WithHandler((Guid? guid) => $"guid:{guid}")
+      .AsCommand()
+      .Done()
+      .Build();
+
+    // Act
+    int exitCode = await app.RunAsync(["test", "--guid", "12345678-1234-1234-1234-123456789012"]);
+
+    // Assert
+    exitCode.ShouldBe(0);
+    terminal.OutputContains("guid:12345678-1234-1234-1234-123456789012").ShouldBeTrue();
+
+    await Task.CompletedTask;
+  }
+
+  public static async Task Should_parse_nullable_datetime_option_with_value()
+  {
+    // Arrange
+    using TestTerminal terminal = new();
+    NuruApp app = NuruApp.CreateBuilder()
+      .UseTerminal(terminal)
+      .Map("test --date {date:datetime?}")
+      .WithHandler((DateTime? date) => $"date:{date:yyyy-MM-dd}")
+      .AsCommand()
+      .Done()
+      .Build();
+
+    // Act
+    int exitCode = await app.RunAsync(["test", "--date", "2024-01-15"]);
+
+    // Assert
+    exitCode.ShouldBe(0);
+    terminal.OutputContains("date:2024-01-15").ShouldBeTrue();
+
+    await Task.CompletedTask;
+  }
+
+  public static async Task Should_handle_multiple_nullable_options()
+  {
+    // Arrange
+    using TestTerminal terminal = new();
+    NuruApp app = NuruApp.CreateBuilder()
+      .UseTerminal(terminal)
+      .Map("test --id? {id:long?} --count? {count:int?}")
+      .WithHandler((long? id, int? count) => $"id:{id?.ToString(CultureInfo.InvariantCulture) ?? "null"}|count:{count?.ToString(CultureInfo.InvariantCulture) ?? "null"}")
+      .AsCommand()
+      .Done()
+      .Build();
+
+    // Act
+    int exitCode = await app.RunAsync(["test", "--id", "123"]);
+
+    // Assert
+    exitCode.ShouldBe(0);
+    terminal.OutputContains("id:123").ShouldBeTrue();
+    terminal.OutputContains("count:null").ShouldBeTrue();
+
+    await Task.CompletedTask;
+  }
+}
+
+} // namespace TimeWarp.Nuru.Tests.Routing


### PR DESCRIPTION
## Summary

- Fix source generator to properly handle nullable value types (`long?`, `int?`, etc.) for `[Option]` properties
- Previously, nullable options received `0` (default) instead of `null` when omitted
- Generated code now declares nullable variables and only parses when value is provided

## Changes

- **route-matcher-emitter.cs**: Added nullable type detection in `EmitOptionTypeConversion()` to generate proper nullable handling code
- **routing-25-nullable-value-type-options.cs**: Added 10 comprehensive tests for nullable option types

## Test Plan

- [x] All 10 new nullable option tests pass
- [x] All 1027 CI tests pass (1020 passed + 7 skipped)
- [x] Verified generated code declares `long? id = null` instead of `long id = default`

Fixes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)