### PR TITLE
chore: Bump version to 3.0.0-beta.37

### DIFF
--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -8,7 +8,7 @@
 
   <!-- Default package metadata (can be overridden in individual projects) -->
   <PropertyGroup Label="Package Metadata">
-    <Version>3.0.0-beta.36</Version>
+    <Version>3.0.0-beta.37</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-nuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>


### PR DESCRIPTION
## Summary

- Bump version to 3.0.0-beta.37

🤖 Generated with [Claude Code](https://claude.com/claude-code)