### PR TITLE
chore: Bump version to 3.0.0-beta.38

### DIFF
--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -8,7 +8,7 @@
 
   <!-- Default package metadata (can be overridden in individual projects) -->
   <PropertyGroup Label="Package Metadata">
-    <Version>3.0.0-beta.37</Version>
+    <Version>3.0.0-beta.38</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-nuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- Bump version to 3.0.0-beta.38 for endpoint nullable option fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)