### PR TITLE
chore: Bump version to 3.0.0-beta.40

### DIFF
--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -8,7 +8,7 @@
 
   <!-- Default package metadata (can be overridden in individual projects) -->
   <PropertyGroup Label="Package Metadata">
-    <Version>3.0.0-beta.39</Version>
+    <Version>3.0.0-beta.40</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-nuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
Version bump to 3.0.0-beta.40

This release includes the fix for optional int options routing bug from PR #153.

## Changes
- Bump version from 3.0.0-beta.39 to 3.0.0-beta.40