### PR TITLE
fix: Add null check before TryParse/TryConvert for optional options

### DIFF
--- a/source/timewarp-nuru-analyzers/generators/emitters/route-matcher-emitter.cs
+++ b/source/timewarp-nuru-analyzers/generators/emitters/route-matcher-emitter.cs
@@ -1158,9 +1158,9 @@ internal static class RouteMatcherEmitter
         {
           // Required option value (no default): TryParse with error message on failure
           sb.AppendLine($"      {clrType} {varName} = default;");
-          sb.AppendLine($"      if (!{tryParseCondition})");
+          sb.AppendLine($"      if ({rawVarName} is not null && !{tryParseCondition})");
           sb.AppendLine("      {");
-          sb.AppendLine($"        app.Terminal.WriteLine($\"Error: Invalid value '{{{rawVarName} ?? \"(missing)\"}}' for option '{optionDisplay}'. Expected: {baseType}\");");
+          sb.AppendLine($"        app.Terminal.WriteLine($\"Error: Invalid value '{{{rawVarName}}}' for option '{optionDisplay}'. Expected: {baseType}\");");
           sb.AppendLine("        return 1;");
           sb.AppendLine("      }");
         }
@@ -1190,9 +1190,9 @@ internal static class RouteMatcherEmitter
         }
         else
         {
-          sb.AppendLine($"      if (!global::System.Uri.TryCreate({rawVarName}, global::System.UriKind.RelativeOrAbsolute, out global::System.Uri? {varName}) || {varName} is null)");
+          sb.AppendLine($"      if ({rawVarName} is not null && (!global::System.Uri.TryCreate({rawVarName}, global::System.UriKind.RelativeOrAbsolute, out global::System.Uri? {varName}) || {varName} is null))");
           sb.AppendLine("      {");
-          sb.AppendLine($"        app.Terminal.WriteLine($\"Error: Invalid value '{{{rawVarName} ?? \"(missing)\"}}' for option '{optionDisplay}'. Expected: Uri\");");
+          sb.AppendLine($"        app.Terminal.WriteLine($\"Error: Invalid value '{{{rawVarName}}}' for option '{optionDisplay}'. Expected: Uri\");");
           sb.AppendLine("        return 1;");
           sb.AppendLine("      }");
         }
@@ -1358,7 +1358,7 @@ internal static class RouteMatcherEmitter
     {
       // Required option: direct conversion with error handling
       sb.AppendLine($"      var {converterVarName} = new {converter.ConverterTypeName}();");
-      sb.AppendLine($"      if (!{converterVarName}.TryConvert({rawVarName}, out object? {tempVarName}))");
+      sb.AppendLine($"      if ({rawVarName} is not null && !{converterVarName}.TryConvert({rawVarName}, out object? {tempVarName}))");
       sb.AppendLine("      {");
       sb.AppendLine($"        app.Terminal.WriteLine($\"Error: Invalid {targetType} value for option '{option.LongForm ?? option.ShortForm}': '{{{rawVarName}}}'\");");
       sb.AppendLine("        return 1;");
@@ -1406,9 +1406,9 @@ internal static class RouteMatcherEmitter
     {
       // Required option: direct conversion with error handling
       sb.AppendLine($"      var {converterVarName} = new global::TimeWarp.Nuru.EnumTypeConverter<{baseEnumType}>();");
-      sb.AppendLine($"      if (!{converterVarName}.TryConvert({rawVarName}, out object? {tempVarName}))");
+      sb.AppendLine($"      if ({rawVarName} is not null && !{converterVarName}.TryConvert({rawVarName}, out object? {tempVarName}))");
       sb.AppendLine("      {");
-      sb.AppendLine($"        app.Terminal.WriteLine($\"Error: Invalid value '{{{rawVarName} ?? \"(missing)\"}}' for option '{optionDisplay}'. {{{converterVarName}.GetValidValuesMessage()}}\");");
+      sb.AppendLine($"        app.Terminal.WriteLine($\"Error: Invalid value '{{{rawVarName}}}' for option '{optionDisplay}'. {{{converterVarName}.GetValidValuesMessage()}}\");");
       sb.AppendLine("        return 1;");
       sb.AppendLine("      }");
       sb.AppendLine($"      {baseEnumType} {varName} = ({baseEnumType}){tempVarName}!;");


### PR DESCRIPTION
## Summary
Properly fixes the optional int options routing bug from #152.

## Problem
The previous fix removed the null check from the condition but didn't account for the fact that when an optional option's flag is NOT found, the raw value is still null and calling TryParse/TryConvert with null causes failures.

## Solution
Add `is not null &&` check before attempting TryParse/TryConvert. This allows:
- Route skipping when optional option not provided (rawVarName is null)
- Error display only when value is provided but invalid

## Testing
Will test with ganda to verify `repo setup --dry-run` works correctly.

Fixes #152