### PR TITLE
docs: Add DeepWiki badge to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,7 @@
 [![NuGet Downloads](https://img.shields.io/nuget/dt/TimeWarp.Nuru.svg)](https://www.nuget.org/packages/TimeWarp.Nuru/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/TimeWarpEngineering/timewarp-nuru/build.yml?branch=master)](https://github.com/TimeWarpEngineering/timewarp-nuru/actions)
 [![License](https://img.shields.io/github/license/TimeWarpEngineering/timewarp-nuru.svg)](https://github.com/TimeWarpEngineering/timewarp-nuru/blob/master/LICENSE)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/TimeWarpEngineering/timewarp-nuru)
 
 **Route-based CLI framework for .NET - bringing web-style routing to command-line applications**
 


### PR DESCRIPTION
## Summary

Adds the DeepWiki documentation badge to the readme badges section.

## Changes

- Added DeepWiki badge to the badges section in readme.md

## Verification

- [x] Badge displays correctly in markdown preview
- [x] Links to correct DeepWiki page: https://deepwiki.com/TimeWarpEngineering/timewarp-nuru