### PR TITLE
feat: Support Environment.ExitCode for handler exit codes

### DIFF
--- a/source/timewarp-nuru-analyzers/generators/emitters/route-matcher-emitter.cs
+++ b/source/timewarp-nuru-analyzers/generators/emitters/route-matcher-emitter.cs
@@ -231,12 +231,12 @@ internal static class RouteMatcherEmitter
         sb, route, routeIndex, behaviors, services, indent: 6,
         () => HandlerInvokerEmitter.Emit(sb, route, routeIndex, services, indent: 8, commandAlreadyCreated: commandCreatedByBehavior, loggerFactoryFieldName: loggerFactoryFieldName, useRuntimeDI: useRuntimeDI, runtimeDISuffix: runtimeDISuffix, httpClientConfigurations: httpClientConfigurations));
 
-      sb.AppendLine("      return 0;");
+      sb.AppendLine("      return global::System.Environment.ExitCode;");
     }
     else
     {
       HandlerInvokerEmitter.Emit(sb, route, routeIndex, services, indent: 6, loggerFactoryFieldName: loggerFactoryFieldName, useRuntimeDI: useRuntimeDI, runtimeDISuffix: runtimeDISuffix, httpClientConfigurations: httpClientConfigurations);
-      sb.AppendLine("      return 0;");
+      sb.AppendLine("      return global::System.Environment.ExitCode;");
     }
 
     sb.AppendLine("    }");
@@ -348,12 +348,12 @@ internal static class RouteMatcherEmitter
         sb, route, routeIndex, behaviors, services, indent: 6,
         () => HandlerInvokerEmitter.Emit(sb, route, routeIndex, services, indent: 8, commandAlreadyCreated: commandCreatedByBehavior, loggerFactoryFieldName: loggerFactoryFieldName, useRuntimeDI: useRuntimeDI, runtimeDISuffix: runtimeDISuffix, httpClientConfigurations: httpClientConfigurations));
 
-      sb.AppendLine("      return 0;");
+      sb.AppendLine("      return global::System.Environment.ExitCode;");
     }
     else
     {
       HandlerInvokerEmitter.Emit(sb, route, routeIndex, services, indent: 6, loggerFactoryFieldName: loggerFactoryFieldName, useRuntimeDI: useRuntimeDI, runtimeDISuffix: runtimeDISuffix, httpClientConfigurations: httpClientConfigurations);
-      sb.AppendLine("      return 0;");
+      sb.AppendLine("      return global::System.Environment.ExitCode;");
     }
 
     sb.AppendLine("    }");

--- a/source/timewarp-nuru/nuru-app.cs
+++ b/source/timewarp-nuru/nuru-app.cs
@@ -96,8 +96,8 @@ public partial class NuruApp
   /// outputs "42" to the terminal but still returns exit code 0.
   /// </para>
   /// <para>
-  /// To signal failure with a non-zero exit code, throw an exception from your handler.
-  /// The exception message will be displayed and exit code will be 1.
+  /// To signal failure with a non-zero exit code, set <c>Environment.ExitCode</c>
+  /// in your handler. The value will be returned as the process exit code.
   /// </para>
   /// </returns>
 #pragma warning disable CA1822 // Member does not access instance data 

--- a/tools/dev-cli/commands/check-version-command.cs
+++ b/tools/dev-cli/commands/check-version-command.cs
@@ -90,9 +90,11 @@ internal sealed class CheckVersionCommand : ICommand<Unit>
 
       if (alreadyPublished.Count > 0)
       {
-        throw new InvalidOperationException(
+        Terminal.WriteErrorLine(
           $"Package(s) already published: {string.Join(", ", alreadyPublished)}. " +
           "Please increment the version in source/Directory.Build.props");
+        Environment.ExitCode = 1;
+        return Unit.Value;
       }
 
       Terminal.WriteLine("\nAll packages are ready to publish!");


### PR DESCRIPTION
## Summary
- Generated interceptor code now returns `Environment.ExitCode` instead of hardcoded `0` after handler invocation
- Handlers can set `Environment.ExitCode = 1` (or any value) to signal failure cleanly without throwing exceptions
- Updated `check-version-command` to use the new pattern instead of `throw new InvalidOperationException`
- Updated `RunAsync` doc comments to document the new mechanism

## Test plan
- [x] All 1079 CI tests pass (0 failures, 7 skipped)
- [x] Analyzers, core, and dev-cli all build cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)