### PR TITLE
chore: add CI check-version config

### DIFF
--- a/.timewarp/dev.jsonc
+++ b/.timewarp/dev.jsonc
@@ -1,0 +1,7 @@
+{
+  // Per-repo configuration for TimeWarp.Nuru dev-cli
+  "checkVersionConfig": {
+    "checkVersionStrategy": "nuget-search",
+    "packages": "TimeWarp.Nuru.Analyzers,TimeWarp.Nuru.Mcp,TimeWarp.Nuru,TimeWarp.Nuru.Search,TimeWarp.Nuru.DevCli"
+  }
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,7 +29,6 @@
     <PackageVersion Include="TimeWarp.Jaribu" Version="1.0.0-beta.12" />
     <PackageVersion Include="TimeWarp.Build.Tasks" Version="1.0.0" />
   </ItemGroup>
-
   <ItemGroup Label="Testing">
     <PackageVersion Include="Shouldly" Version="4.3.0" />
   </ItemGroup>
@@ -61,7 +60,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
   </ItemGroup>
   <ItemGroup Label="MCP Server">
-    <PackageVersion Include="ModelContextProtocol" Version="1.0.0-rc.1" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup Label="SQLite">
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.7" />
@@ -75,7 +74,7 @@
     <PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.15.0" />
     <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="4.15.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.203" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="5.3.0" />
   </ItemGroup>
   <ItemGroup Label="Roslyn Analyzer Dependencies">

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -8,7 +8,7 @@
 
   <!-- Default package metadata (can be overridden in individual projects) -->
   <PropertyGroup Label="Package Metadata">
-    <Version>3.0.0-beta.69</Version>
+    <Version>3.0.0-beta.70</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-nuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- Add `.timewarp/dev.jsonc` with package list for `check-version` command in CI
- Update ModelContextProtocol to 1.2.0 and BannedApiAnalyzers to 3.3.4
- Bump version to 3.0.0-beta.70