### PR TITLE
fix: render [Parameter(Description)] in per-command --help (#215)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -436,3 +436,8 @@ dotnet_diagnostic.IDE1006.severity = none
 
 # IDE0290: Use primary constructor
 csharp_style_prefer_primary_constructors = false
+
+# ganda repo audit configuration
+[ganda.audit]
+# This IS the TimeWarp.Nuru repo, so it cannot reference TimeWarp.Nuru as a package.
+nuru.severity = off

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,11 +21,12 @@
   "peacock.remoteColor": "#3957CF",
   "cSpell.words": [
     "Cocona",
-    "Fx\u0027s",
+    "Fx's",
     "LINQ",
     "Nuru",
     "Ryzen",
     "Stackalloc"
   ],
-  "timewarp.blurImagePath": "assets/timewarp-nuru-avatar.svg"
+  "timewarp.blurImagePath": "assets/timewarp-nuru-avatar.svg",
+  "window.title": "timewarp-nuru · ${rootName}${separator}${activeEditorShort}"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "ganda: window icon",
+      "type": "shell",
+      "command": "ganda repo avatar window",
+      "runOptions": {
+        "runOn": "folderOpen"
+      },
+      "presentation": {
+        "reveal": "silent",
+        "echo": false
+      },
+      "problemMatcher": []
+    }
+  ]
+}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,3 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
 
   <!-- Import repository path definitions -->
@@ -86,6 +87,12 @@
   <!-- Banned API Symbols -->
   <ItemGroup Label="Banned API Analyzers">
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)BannedSymbols.txt" />
+  </ItemGroup>
+
+  <!-- Git commit metadata for assemblies (repo-wide). timewarp-nuru.csproj overrides
+       PrivateAssets to "none" so it flows transitively to package consumers. -->
+  <ItemGroup Label="Build Tasks">
+    <PackageReference Include="TimeWarp.Build.Tasks" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestMinor",
+    "allowPrerelease": false
+  }
+}

--- a/kanban/to-do/453-render-parameter-description-in-per-command-help-output.md
+++ b/kanban/to-do/453-render-parameter-description-in-per-command-help-output.md
@@ -1,0 +1,121 @@
+# Render Parameter Description In Per Command Help Output
+
+## Description
+
+When using the Endpoint DSL with `[NuruRoute]` + `[Parameter(Description = "...")]`, the
+description is correctly extracted into `ParameterDefinition.Description`, but it is **never
+included** in the generated per-route `--help` Parameters table.
+
+Only the Fluent DSL pipe syntax (`{param|Description here}`) produces visible parameter
+descriptions in help output — and even then, only via the options path. The per-route Parameters
+table hardcodes Name/Required/Type columns and ignores `Description`.
+
+Tracks GitHub issue: https://github.com/TimeWarpEngineering/timewarp-nuru/issues/215
+
+## Reproduction
+
+```csharp
+[Parameter(Description = "Source repository (owner/repo, https://..., or git@...:.git)")]
+public required string Source { get; set; }
+```
+
+```
+ganda repo fork --help
+
+Parameters:
+┌────────┬──────────┬────────┐
+│ Name   │ Required │ Type   │
+├────────┼──────────┼────────┤
+│ source │ Yes      │ string │
+└────────┴──────────┴────────┘
+```
+
+No description is shown for `source`, despite a high-quality `[Parameter(Description)]` being present.
+
+## Root Cause
+
+In `source/timewarp-nuru-analyzers/generators/emitters/route-help-emitter.cs`, the
+`EmitRouteHelpContent` method hardcodes the parameters table:
+
+```csharp
+.AddColumn("Name")
+.AddColumn("Required")
+.AddColumn("Type")
+...
+.AddRow(name, required, type)  // param.Description is ignored
+```
+
+(Lines ~119-141 in the current emitter.)
+
+`ParameterDefinition` (`segment-definition.cs:49`) includes `Description`, populated by:
+- `endpoint-extractor.cs:762-764` (for `[Parameter(Description = ...)]`)
+- `pattern-string-extractor.cs:133` (for fluent `{name|desc}` syntax)
+
+Options already emit a Description column (lines ~150-178 in the same file). Parameter
+descriptions are also captured for shell completion (`completion-data-extractor.cs:101`), so the
+data is present — it's only the help emitter that drops it.
+
+## Impact
+
+- Endpoint DSL users (the recommended pattern for non-trivial apps) get incomplete `--help`
+  for any command with positional parameters.
+- Descriptions written on `[Parameter]` attributes are invisible in the most common help path.
+- Inconsistent behavior between Fluent DSL and Endpoint DSL.
+
+## Suggested Fix
+
+Update `RouteHelpEmitter.EmitRouteHelpContent` to add a "Description" column to the Parameters
+table when any parameter has a description, mirroring the existing options handling. Gracefully
+omit the column (or show empty cells) when no descriptions are present.
+
+## Checklist
+
+- [x] Add conditional "Description" column to the Parameters table in `route-help-emitter.cs`
+- [x] Mirror the options-table logic (only show column when at least one param has a description)
+- [x] Verify Endpoint DSL `[Parameter(Description)]` renders in per-command `--help`
+- [x] Verify Fluent DSL `{param|desc}` renders consistently
+- [x] Add test covering parameter descriptions in per-route help output
+- [x] Run `ganda runfile cache --clear` then help tests; all help tests pass
+- [ ] Close GitHub issue #215 referencing the fix (do at merge to master)
+
+## Implementation
+
+- `source/timewarp-nuru-analyzers/generators/emitters/route-help-emitter.cs`:
+  `EmitRouteHelpContent` now computes `anyDescriptions` over the route parameters and adds a
+  `.AddColumn("Description")` plus a 4-column `.AddRow(...)` when any parameter has a description.
+  When none do, the original 3-column (Name/Required/Type) table is emitted unchanged. Mirrors the
+  existing Options-table handling.
+- `tests/timewarp-nuru-tests/help/help-01-per-route-help.cs`: added
+  `Should_show_parameter_descriptions_in_help` (Endpoint DSL `ForkEndpoint` with
+  `[Parameter(Description = "Source repository identifier")]`, asserts the Description column +
+  text render) and `Should_not_show_description_column_when_no_parameter_descriptions` (asserts the
+  column is omitted when no parameter has a description). Used `.Map<TEndpoint>()` per the
+  CI multi-mode cross-contamination guidance.
+
+## Verification
+
+- Full CI multi-mode suite passes under the project's SDK (.NET 10):
+  **Total 1129, Passed 1122, Skipped 7, Failed 0** via
+  `dotnet run tests/ci-tests/run-ci-tests.cs` (SDK pinned to 10.0.301).
+- All help tests also verified individually: help-01 10/10 (+1 skipped), help-02 default 6/6,
+  help-02 table 9/9, help-03 endpoint 4/4, help-04 group 6/6, help-05 1/1, help-06 param-only 7/7.
+- Environment note (not related to this change): Nuru is a .NET 10 project (CI pins
+  `dotnet-version: '10.0.x'`; no `global.json`). This dev machine also has .NET 11 preview
+  (11.0.100-preview.5) installed, so with no `global.json` the default `dotnet` resolves to the
+  preview, which mis-enforces code-style analyzers and fails to build the **existing** analyzer
+  source (reproduces on a clean `git stash` baseline). Build/test with .NET 10. On the 10.0.301
+  patch the file-based CI runner also needs
+  `--property:ExperimentalFileBasedProgramEnableTransitiveDirectives=true`; CI's newer 10.0.x
+  patch and the `dev.cs` workflow have it enabled by default.
+
+## Notes
+
+- Help rendering is done at compile time by source generator emitters.
+- Affected version: TimeWarp.Nuru 3.0.0-beta.70 (and likely earlier).
+- Observed quirk: the Fluent DSL `{name|desc}` description parser strips `(`, `)`, and `/` from
+  the description text (e.g. `Source repository (owner/repo)` renders as
+  `Source repository owner repo`). The Endpoint DSL `[Parameter(Description)]` path preserves the
+  text verbatim. The stripping is a separate fluent-parser issue, out of scope for #215 — consider
+  a follow-up task if desired.
+- Related: #434 (review/clean up help-model.cs — notes "No support exists for ... parameter
+  descriptions"), #436 (add Examples support to help output).

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -33,8 +33,6 @@
     <None Include="$(RepositoryRoot)assets/logo.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
-  <ItemGroup Label="Build Tasks">
-    <PackageReference Include="TimeWarp.Build.Tasks" />
-  </ItemGroup>
+  <!-- TimeWarp.Build.Tasks is referenced repo-wide in the root Directory.Build.props. -->
 
 </Project>

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -8,7 +8,7 @@
 
   <!-- Default package metadata (can be overridden in individual projects) -->
   <PropertyGroup Label="Package Metadata">
-    <Version>3.0.0-beta.70</Version>
+    <Version>3.0.0-beta.71</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-nuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>

--- a/source/timewarp-nuru-analyzers/generators/emitters/route-help-emitter.cs
+++ b/source/timewarp-nuru-analyzers/generators/emitters/route-help-emitter.cs
@@ -111,15 +111,22 @@ internal static class RouteHelpEmitter
     }
 
     // Parameters section
-    IEnumerable<ParameterDefinition> parameters = route.Parameters.ToList();
-    if (parameters.Any())
+    List<ParameterDefinition> parameters = [.. route.Parameters];
+    if (parameters.Count > 0)
     {
+      // Only show the Description column when at least one parameter has a description.
+      bool anyDescriptions = parameters.Any(p => !string.IsNullOrEmpty(p.Description));
+
       sb.AppendLine($"{indentStr}app.Terminal.WriteLine();");
       sb.AppendLine($"{indentStr}app.Terminal.WriteLine(\"Parameters:\");");
       sb.AppendLine($"{indentStr}app.Terminal.WriteTable(table => table");
       sb.AppendLine($"{indentStr}  .AddColumn(\"Name\")");
       sb.AppendLine($"{indentStr}  .AddColumn(\"Required\")");
       sb.AppendLine($"{indentStr}  .AddColumn(\"Type\")");
+      if (anyDescriptions)
+      {
+        sb.AppendLine($"{indentStr}  .AddColumn(\"Description\")");
+      }
 
       foreach (ParameterDefinition param in parameters)
       {
@@ -134,7 +141,15 @@ internal static class RouteHelpEmitter
           ? param.TypeConstraint
           : "string";
 
-        sb.AppendLine($"{indentStr}  .AddRow(\"{EscapeString(name)}\", \"{EscapeString(required)}\", \"{EscapeString(type)}\")");
+        if (anyDescriptions)
+        {
+          string description = param.Description ?? "";
+          sb.AppendLine($"{indentStr}  .AddRow(\"{EscapeString(name)}\", \"{EscapeString(required)}\", \"{EscapeString(type)}\", \"{EscapeString(description)}\")");
+        }
+        else
+        {
+          sb.AppendLine($"{indentStr}  .AddRow(\"{EscapeString(name)}\", \"{EscapeString(required)}\", \"{EscapeString(type)}\")");
+        }
       }
 
       sb.AppendLine($"{indentStr});");

--- a/tests/timewarp-nuru-tests/help/help-01-per-route-help.cs
+++ b/tests/timewarp-nuru-tests/help/help-01-per-route-help.cs
@@ -145,6 +145,52 @@ public class PerRouteHelpTests
     terminal.OutputContains("destination").ShouldBeTrue();
   }
 
+  public static async Task Should_show_parameter_descriptions_in_help()
+  {
+    // Issue #215 / kanban #453: Endpoint DSL [Parameter(Description)] must render
+    // in per-route help (previously the Parameters table dropped the description).
+    // Arrange
+    using TestTerminal terminal = new();
+    NuruApp app = NuruApp.CreateBuilder()
+      .UseTerminal(terminal)
+      .Map<ForkEndpoint>()
+      .Build();
+
+    // Act
+    int exitCode = await app.RunAsync(["fork", "--help"]);
+
+    // Assert
+    exitCode.ShouldBe(0);
+    terminal.OutputContains("Parameters").ShouldBeTrue();
+    terminal.OutputContains("source").ShouldBeTrue();
+    terminal.OutputContains("Description").ShouldBeTrue();
+    terminal.OutputContains("Source repository identifier").ShouldBeTrue();
+  }
+
+  public static async Task Should_not_show_description_column_when_no_parameter_descriptions()
+  {
+    // Issue #215 / kanban #453: omit the Description column when no parameter has one.
+    // Arrange
+    using TestTerminal terminal = new();
+    NuruApp app = NuruApp.CreateBuilder()
+      .UseTerminal(terminal)
+      .Map("move {source} {destination}")
+        .WithHandler((string source, string destination) => "moved")
+        .WithDescription("Move files")
+        .Done()
+      .Build();
+
+    // Act
+    int exitCode = await app.RunAsync(["move", "--help"]);
+
+    // Assert - parameters render, but no Description column header appears
+    exitCode.ShouldBe(0);
+    terminal.OutputContains("Parameters").ShouldBeTrue();
+    terminal.OutputContains("source").ShouldBeTrue();
+    terminal.OutputContains("destination").ShouldBeTrue();
+    terminal.OutputContains("Description").ShouldBeFalse();
+  }
+
   public static async Task Should_show_options_section_in_help()
   {
     // Arrange
@@ -219,6 +265,23 @@ public static class StaticFlags
   {
     DangerousHandlerExecuted = true;
     return "executed";
+  }
+}
+
+// Issue #215 / kanban #453: Endpoint DSL endpoint with a described parameter.
+[NuruRoute("fork", Description = "Fork a repository")]
+internal sealed class ForkEndpoint : ICommand<Unit>
+{
+  [Parameter(Description = "Source repository identifier")]
+  public required string Source { get; set; }
+
+  internal sealed class Handler(ITerminal terminal) : ICommandHandler<ForkEndpoint, Unit>
+  {
+    public async ValueTask<Unit> Handle(ForkEndpoint command, CancellationToken ct)
+    {
+      await terminal.WriteLineAsync($"forked {command.Source}").ConfigureAwait(false);
+      return default;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #215 — Endpoint DSL `[Parameter(Description = "...")]` is now rendered in per-command `--help` output. Also bundles a few repo/build hygiene fixes that surfaced while verifying the change.

## Changes

### Fix #215 (`route-help-emitter.cs`)
The per-route help emitter hardcoded a Name/Required/Type parameters table and ignored `ParameterDefinition.Description`, so descriptions written via the Endpoint DSL never appeared in `command --help`. `EmitRouteHelpContent` now adds a **Description** column (mirroring the existing options-table logic) when at least one parameter has a description, and leaves the original 3-column table unchanged otherwise.

```
Parameters:
┌────────┬──────────┬────────┬──────────────────────────────┐
│ Name   │ Required │ Type   │ Description                  │
├────────┼──────────┼────────┼──────────────────────────────┤
│ source │ Yes      │ string │ Source repository identifier │
└────────┴──────────┴────────┴──────────────────────────────┘
```

Added positive (Endpoint DSL) + negative tests in `help-01-per-route-help.cs`, and kanban task #453.

### Build / env hygiene
- **`global.json`** — pins the SDK to `10.0.x` (`rollForward: latestMinor`, `allowPrerelease: false`) so an installed .NET 11 preview no longer hijacks `dotnet` in this repo. CI already uses `dotnet-version: '10.0.x'`.
- **Duplicate `TimeWarp.Build.Tasks` (NU1504)** — it was declared in both the root and `source/Directory.Build.props`, and `source/` imports the root, so `source/*` projects got it twice. Now declared once repo-wide in the root (covering non-source projects too); `timewarp-nuru.csproj`'s `Update PrivateAssets="none"` still flows it transitively to consumers.

### Repo audit fixes
- Disable the `ganda` **nuru** audit check via `[ganda.audit]` in `.editorconfig` (this *is* the TimeWarp.Nuru repo, so it can't reference itself as a package).
- Add `.vscode` window-icon config (`window.title` + `tasks.json`) for the `vscode-window-icon` check.

## Testing

Full CI multi-mode suite under .NET 10: **1129 total, 1122 passed, 7 skipped, 0 failed**. `dotnet restore timewarp-nuru.slnx` is clean (no NU1504).

## Notes

- Observed (out of scope): the Fluent DSL `{name|desc}` description parser strips `(`, `)`, and `/` from the text; the Endpoint DSL `[Parameter(Description)]` path preserves it verbatim. Candidate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)