### PR TITLE
chore: bump version to 3.0.0-beta.75

### DIFF
--- a/kanban/in-progress/466-ship-300-beta75-with-route-examples-in-help-and-capabilities-464.md
+++ b/kanban/in-progress/466-ship-300-beta75-with-route-examples-in-help-and-capabilities-464.md
@@ -1,0 +1,29 @@
+# Ship 3.0.0-beta.75 with route examples in help and capabilities (464)
+
+## Description
+
+Release TimeWarp.Nuru 3.0.0-beta.75 carrying task 464: `[NuruRouteExample]` / `.WithExample()`
+rendered in per-route `--help` and emitted in `--capabilities`, plus the fluent named-argument
+fix and the diagnostics-swallowing generator fix (aborted Build() chains now fail the build
+instead of compiling silently). Merged to master via PR #223 (merge 17ab7778).
+
+Downstream consumer: timewarp-ganda task 211 (annotate `skills add` with examples) unblocks on
+this release.
+
+## Checklist
+
+- [ ] Bump `<Version>` to 3.0.0-beta.75 in source/Directory.Build.props (PR to master)
+- [ ] Merge bump PR; master push CI green (Packages artifact built)
+- [ ] `dev release --dry-run` from clean synced master worktree — 8 guards pass
+- [ ] `dev release` — tag v3.0.0-beta.75 + GitHub Release
+- [ ] Watch `release:published` run through verify → push (OIDC)
+- [ ] Confirm packages on NuGet (flatcontainer)
+
+## Notes
+
+- Release procedure per tw-release skill / documentation/developer/guides/releasing.md —
+  version typed exactly once (the bump PR); pipeline promotes the CI-built artifact.
+
+## Session
+
+- Created: 0f730c83-90e5-4a4c-8bb2-3020fdd469d6 (2026-08-14)

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -13,7 +13,7 @@
 
   <!-- Default package metadata (can be overridden in individual projects) -->
   <PropertyGroup Label="Package Metadata">
-    <Version>3.0.0-beta.74</Version>
+    <Version>3.0.0-beta.75</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-nuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>


### PR DESCRIPTION
## Summary

- Bump `<Version>` to 3.0.0-beta.75 for the release carrying route Examples support (task 464, PR #223)
- Adds release kanban task 466

## Test plan

- [x] ganda repo audit (attested on commit)
- [ ] Master push CI green after merge (builds the Packages artifact the release promotes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)