### PR TITLE
fix: add PackageProjectUrl to package metadata

### DIFF
--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -1,3 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <!-- Import parent Directory.Build.props -->
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
@@ -16,6 +17,7 @@
     <Version>3.0.0-beta.75</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-nuru</RepositoryUrl>
+    <PackageProjectUrl>https://timewarp.software/projects/timewarp-nuru/</PackageProjectUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>
     <PackageIcon>logo.png</PackageIcon>
     <PackageReadmeFile>readme.md</PackageReadmeFile>


### PR DESCRIPTION
## Summary

- Add `<PackageProjectUrl>` (https://timewarp.software/projects/timewarp-nuru/) to source/Directory.Build.props package metadata
- Fixes the `nuget-package-urls` audit check that blocks ganda attestation on master, which gates the beta.75 release

## Test plan

- [x] ganda repo audit --checks nuget-package-urls — pass
- [x] Full ganda repo audit — pass (attested on commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)